### PR TITLE
feat: implement full Soroban contract test suite (closes #69)

### DIFF
--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -1,1 +1,2 @@
 /target
+/test_snapshots

--- a/contracts/src/airline/lib.rs
+++ b/contracts/src/airline/lib.rs
@@ -99,6 +99,13 @@ pub struct BatchUpdateFlightStatusResult {
 
 #[contracttype]
 #[derive(Clone)]
+pub struct PriceUpdateInput {
+    pub base_price: i128,
+    pub factors: PricingFactors,
+}
+
+#[contracttype]
+#[derive(Clone)]
 pub struct PriceHistoryEntry {
     pub timestamp: u64,
     pub old_price: i128,

--- a/contracts/src/booking/lib.rs
+++ b/contracts/src/booking/lib.rs
@@ -41,16 +41,20 @@ impl BookingStorage {
     pub fn get(env: &Env, booking_id: u64) -> Option<Booking> {
         env.storage().persistent().get(&booking_id)
     }
-    
+
     pub fn set(env: &Env, booking_id: u64, booking: &Booking) {
         env.storage().persistent().set(&booking_id, booking);
+    }
+
+    pub fn next_id(env: &Env) -> u64 {
+        let id: u64 = env.storage().instance().get(&symbol_short!("bk_next")).unwrap_or(1u64);
+        env.storage().instance().set(&symbol_short!("bk_next"), &(id + 1));
+        id
     }
 }
 
 #[contract]
 pub struct BookingContract;
-
-const MAX_BATCH_SIZE: u32 = 50;
 
 #[contractimpl]
 impl BookingContract {
@@ -67,8 +71,8 @@ impl BookingContract {
         token: Address,
     ) -> u64 {
         passenger.require_auth();
-        
-        let booking_id = env.ledger().timestamp();
+
+        let booking_id = BookingStorage::next_id(&env);
         
         let booking = Booking {
             booking_id,
@@ -303,5 +307,76 @@ impl BookingContract {
             failures,
             total_released,
         }
+    }
+
+    /// Store the trusted oracle address so oracle-triggered settlement is permitted.
+    pub fn initialize_oracle(env: Env, admin: Address, oracle: Address) {
+        admin.require_auth();
+        assert!(
+            env.storage().instance().get::<_, Address>(&symbol_short!("oracle")).is_none(),
+            "Oracle already set"
+        );
+        env.storage().instance().set(&symbol_short!("oracle"), &oracle);
+    }
+
+    /// Called by the oracle after consensus on flight completion to release escrowed funds.
+    pub fn oracle_release_payment(env: Env, oracle: Address, booking_id: u64) {
+        oracle.require_auth();
+        let trusted: Address = env.storage().instance()
+            .get(&symbol_short!("oracle"))
+            .expect("Oracle not configured");
+        assert!(oracle == trusted, "Unauthorized oracle");
+
+        let mut booking = BookingStorage::get(&env, booking_id).expect("Booking not found");
+        assert!(booking.status == symbol_short!("confirmed"), "Invalid booking status");
+        assert!(booking.amount_escrowed > 0, "No funds in escrow");
+
+        let token_client = token::Client::new(&env, &booking.token);
+        token_client.transfer(
+            &env.current_contract_address(),
+            &booking.airline,
+            &booking.amount_escrowed,
+        );
+
+        let released = booking.amount_escrowed;
+        booking.amount_escrowed = 0;
+        booking.status = symbol_short!("completed");
+        BookingStorage::set(&env, booking_id, &booking);
+
+        env.events().publish(
+            (symbol_short!("oracle"), symbol_short!("released")),
+            (booking_id, released),
+        );
+    }
+
+    /// Called by the oracle after consensus on airline cancellation to refund the passenger.
+    pub fn oracle_refund_airline_cancel(env: Env, oracle: Address, booking_id: u64) {
+        oracle.require_auth();
+        let trusted: Address = env.storage().instance()
+            .get(&symbol_short!("oracle"))
+            .expect("Oracle not configured");
+        assert!(oracle == trusted, "Unauthorized oracle");
+
+        let mut booking = BookingStorage::get(&env, booking_id).expect("Booking not found");
+        assert!(booking.status == symbol_short!("confirmed"), "Invalid booking status");
+
+        if booking.amount_escrowed > 0 {
+            let token_client = token::Client::new(&env, &booking.token);
+            token_client.transfer(
+                &env.current_contract_address(),
+                &booking.passenger,
+                &booking.amount_escrowed,
+            );
+        }
+
+        let refunded = booking.amount_escrowed;
+        booking.amount_escrowed = 0;
+        booking.status = symbol_short!("refunded");
+        BookingStorage::set(&env, booking_id, &booking);
+
+        env.events().publish(
+            (symbol_short!("oracle"), symbol_short!("refunded")),
+            (booking_id, refunded),
+        );
     }
 }

--- a/contracts/src/dispute/lib.rs
+++ b/contracts/src/dispute/lib.rs
@@ -520,11 +520,7 @@ impl DisputeContract {
             DisputeStorageKey::get_vote_reveal(&env, dispute_id, &juror).is_none(),
             "Already revealed"
         );
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> d189056bc32006ab8b0aa25d06bc5f163c0367f2
         // Build hash input - vote (1 byte) + salt (32 bytes) = 33 bytes
         let mut hash_bytes = Bytes::new(&env);
         hash_bytes.push_back(if vote_for_passenger { 1u8 } else { 0u8 });
@@ -532,20 +528,9 @@ impl DisputeContract {
         for byte in salt_bytes.iter() {
             hash_bytes.push_back(*byte);
         }
-<<<<<<< HEAD
-        
-        let computed_hash: BytesN<32> = env.crypto().keccak256(&hash_bytes).into();
-        assert!(
-            computed_hash == commit.commit_hash,
-            "Invalid reveal"
-        );
-        
-=======
 
         let computed_hash: BytesN<32> = env.crypto().keccak256(&hash_bytes).into();
         assert!(computed_hash == commit.commit_hash, "Invalid reveal");
-
->>>>>>> d189056bc32006ab8b0aa25d06bc5f163c0367f2
         let reveal = VoteReveal {
             dispute_id,
             juror: juror.clone(),

--- a/contracts/src/storage_version/lib.rs
+++ b/contracts/src/storage_version/lib.rs
@@ -150,11 +150,7 @@ impl VersionedStorage {
         _migrator: &Address,
     ) -> bool {
         let _step_key = (symbol_short!("mig_step"), contract_type, from, to);
-<<<<<<< HEAD
-        
-=======
 
->>>>>>> d189056bc32006ab8b0aa25d06bc5f163c0367f2
         env.events().publish(
             (symbol_short!("mig"), symbol_short!("step_beg")),
             (contract_type.clone(), from, to),

--- a/contracts/tests/admin_multisig_test.rs
+++ b/contracts/tests/admin_multisig_test.rs
@@ -1,0 +1,723 @@
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Env, Symbol, Vec,
+};
+use traqora_contracts::admin::{AdminActionType, AdminMultisig, AdminMultisigClient};
+
+mod common;
+
+// ── Setup helpers ─────────────────────────────────────────────────────────────
+
+fn new_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env
+}
+
+fn make_client(env: &Env) -> AdminMultisigClient<'static> {
+    let id = env.register(AdminMultisig, ());
+    AdminMultisigClient::new(env, &id)
+}
+
+fn make_signers(env: &Env, n: usize) -> Vec<Address> {
+    let mut v = Vec::new(env);
+    for _ in 0..n {
+        v.push_back(Address::generate(env));
+    }
+    v
+}
+
+fn advance_time(env: &Env, secs: u64) {
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp() + secs,
+        protocol_version: env.ledger().protocol_version(),
+        sequence_number: env.ledger().sequence() + 1,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 16,
+        max_entry_ttl: 6312000,
+    });
+}
+
+// ── Happy-path tests ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_initialize() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let config = client.get_multisig_config().unwrap();
+    assert_eq!(config.threshold, 2);
+    assert_eq!(config.signers.len(), 3);
+    assert_eq!(config.proposal_expiration, 86400);
+    assert!(!client.is_emergency_stopped());
+    assert_eq!(client.get_proposal_count(), 0);
+}
+
+#[test]
+fn test_query_functions_before_init() {
+    let env = new_env();
+    let client = make_client(&env);
+    let addr = Address::generate(&env);
+
+    assert!(client.get_multisig_config().is_none());
+    assert_eq!(client.get_proposal_count(), 0);
+    assert!(!client.is_emergency_stopped());
+    assert!(!client.is_signer_address(&addr));
+}
+
+#[test]
+fn test_is_signer_address() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    assert!(client.is_signer_address(&signers.get(0).unwrap()));
+    assert!(client.is_signer_address(&signers.get(1).unwrap()));
+    assert!(client.is_signer_address(&signers.get(2).unwrap()));
+
+    let outsider = Address::generate(&env);
+    assert!(!client.is_signer_address(&outsider));
+}
+
+#[test]
+fn test_propose_and_execute_emergency_stop() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None,
+        &None,
+        &None,
+        &None,
+        &None,
+    );
+    assert_eq!(pid, 1);
+    assert_eq!(client.get_proposal_count(), 1);
+
+    // Proposer auto-approves
+    assert!(client.has_approved(&pid, &signers.get(0).unwrap()));
+
+    let proposal = client.get_proposal(&pid).unwrap();
+    assert_eq!(proposal.proposal_id, 1);
+    assert!(!proposal.executed);
+    assert!(!proposal.cancelled);
+    assert_eq!(proposal.approvals.len(), 1);
+
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    assert!(client.has_approved(&pid, &signers.get(1).unwrap()));
+
+    assert!(!client.is_emergency_stopped());
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+    assert!(client.is_emergency_stopped());
+
+    let proposal = client.get_proposal(&pid).unwrap();
+    assert!(proposal.executed);
+}
+
+#[test]
+fn test_propose_and_execute_emergency_resume() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid_stop = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid_stop);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid_stop);
+    assert!(client.is_emergency_stopped());
+
+    let pid_resume = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyResume,
+        &None, &None, &None, &None, &None,
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid_resume);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid_resume);
+    assert!(!client.is_emergency_stopped());
+}
+
+#[test]
+fn test_propose_and_execute_parameter_change() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let key = Symbol::new(&env, "fee_bps");
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::ParameterChange,
+        &None,
+        &Some(key.clone()),
+        &Some(250i128),
+        &None,
+        &None,
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+
+    let proposal = client.get_proposal(&pid).unwrap();
+    assert!(proposal.executed);
+    assert_eq!(proposal.parameter_key, Some(key));
+    assert_eq!(proposal.parameter_value, Some(250i128));
+}
+
+#[test]
+fn test_propose_and_execute_add_signer() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let new_signer = Address::generate(&env);
+    assert!(!client.is_signer_address(&new_signer));
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::AddSigner,
+        &None, &None, &None,
+        &Some(new_signer.clone()),
+        &None,
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+
+    assert!(client.is_signer_address(&new_signer));
+    let config = client.get_multisig_config().unwrap();
+    assert_eq!(config.signers.len(), 4);
+}
+
+#[test]
+fn test_propose_and_execute_remove_signer() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 4);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let signer_to_remove = signers.get(3).unwrap();
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::RemoveSigner,
+        &None, &None, &None,
+        &Some(signer_to_remove.clone()),
+        &None,
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+
+    assert!(!client.is_signer_address(&signer_to_remove));
+    let config = client.get_multisig_config().unwrap();
+    assert_eq!(config.signers.len(), 3);
+}
+
+#[test]
+fn test_propose_and_execute_update_threshold() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 5);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::UpdateThreshold,
+        &None, &None, &None, &None,
+        &Some(3u32),
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+
+    let config = client.get_multisig_config().unwrap();
+    assert_eq!(config.threshold, 3);
+}
+
+#[test]
+fn test_propose_and_execute_contract_upgrade() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let target = Address::generate(&env);
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::ContractUpgrade,
+        &Some(target),
+        &None, &None, &None, &None,
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+
+    let proposal = client.get_proposal(&pid).unwrap();
+    assert!(proposal.executed);
+}
+
+#[test]
+fn test_cancel_proposal() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+
+    client.cancel_proposal(&signers.get(0).unwrap(), &pid);
+
+    let proposal = client.get_proposal(&pid).unwrap();
+    assert!(proposal.cancelled);
+    assert!(!proposal.executed);
+}
+
+#[test]
+fn test_multiple_proposals_increment_counter() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let p1 = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+    let p2 = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyResume,
+        &None, &None, &None, &None, &None,
+    );
+    let p3 = client.propose_admin_action(
+        &signers.get(1).unwrap(),
+        &AdminActionType::ParameterChange,
+        &None,
+        &Some(Symbol::new(&env, "k")),
+        &Some(1i128),
+        &None, &None,
+    );
+
+    assert_eq!(p1, 1);
+    assert_eq!(p2, 2);
+    assert_eq!(p3, 3);
+    assert_eq!(client.get_proposal_count(), 3);
+}
+
+#[test]
+fn test_threshold_3_of_5_requires_three_approvals() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 5);
+    client.initialize(&signers, &3u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+
+    // Proposer = 1 approval; need 2 more
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    client.approve_admin_action(&signers.get(2).unwrap(), &pid);
+
+    let proposal = client.get_proposal(&pid).unwrap();
+    assert_eq!(proposal.approvals.len(), 3);
+
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+    assert!(client.is_emergency_stopped());
+}
+
+// ── Negative / error tests ────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Already initialized")]
+fn test_initialize_twice_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+    client.initialize(&signers, &2u32, &86400u64);
+}
+
+#[test]
+#[should_panic(expected = "Threshold exceeds signer count")]
+fn test_initialize_threshold_exceeds_signers() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 2);
+    client.initialize(&signers, &3u32, &86400u64);
+}
+
+#[test]
+#[should_panic(expected = "Threshold must be at least 2")]
+fn test_initialize_threshold_below_2() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &1u32, &86400u64);
+}
+
+#[test]
+#[should_panic(expected = "Not an authorized signer")]
+fn test_propose_unauthorized_signer() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let outsider = Address::generate(&env);
+    client.propose_admin_action(
+        &outsider,
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Parameter key required")]
+fn test_propose_parameter_change_missing_key() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::ParameterChange,
+        &None, &None, &Some(100i128), &None, &None,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Parameter value required")]
+fn test_propose_parameter_change_missing_value() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::ParameterChange,
+        &None,
+        &Some(Symbol::new(&env, "key")),
+        &None, &None, &None,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Target address required")]
+fn test_propose_add_signer_missing_address() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::AddSigner,
+        &None, &None, &None, &None, &None,
+    );
+}
+
+#[test]
+#[should_panic(expected = "New threshold required")]
+fn test_propose_update_threshold_missing_value() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::UpdateThreshold,
+        &None, &None, &None, &None, &None,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Not an authorized signer")]
+fn test_approve_by_non_signer_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+
+    let outsider = Address::generate(&env);
+    client.approve_admin_action(&outsider, &pid);
+}
+
+#[test]
+#[should_panic(expected = "Already approved")]
+fn test_double_approval_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+
+    // signers[0] already approved as proposer
+    client.approve_admin_action(&signers.get(0).unwrap(), &pid);
+}
+
+#[test]
+#[should_panic(expected = "Insufficient approvals")]
+fn test_execute_without_enough_approvals_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    // Only proposer has approved (1 of 2 needed)
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+}
+
+#[test]
+#[should_panic(expected = "Already executed")]
+fn test_execute_twice_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+}
+
+#[test]
+#[should_panic(expected = "Proposal expired")]
+fn test_approve_expired_proposal_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &3600u64); // 1 hour expiry
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+
+    advance_time(&env, 7200); // 2 hours later
+
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+}
+
+#[test]
+#[should_panic(expected = "Proposal expired")]
+fn test_execute_expired_proposal_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &3600u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+
+    advance_time(&env, 7200);
+
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+}
+
+#[test]
+#[should_panic(expected = "Proposal cancelled")]
+fn test_approve_cancelled_proposal_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+
+    client.cancel_proposal(&signers.get(0).unwrap(), &pid);
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+}
+
+#[test]
+#[should_panic(expected = "Proposal cancelled")]
+fn test_execute_cancelled_proposal_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    client.cancel_proposal(&signers.get(0).unwrap(), &pid);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+}
+
+#[test]
+#[should_panic(expected = "Only proposer can cancel")]
+fn test_cancel_by_non_proposer_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+
+    client.cancel_proposal(&signers.get(1).unwrap(), &pid);
+}
+
+#[test]
+#[should_panic(expected = "Already cancelled")]
+fn test_cancel_already_cancelled_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+
+    client.cancel_proposal(&signers.get(0).unwrap(), &pid);
+    client.cancel_proposal(&signers.get(0).unwrap(), &pid);
+}
+
+#[test]
+#[should_panic(expected = "Already executed")]
+fn test_cancel_already_executed_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::EmergencyStop,
+        &None, &None, &None, &None, &None,
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+    client.cancel_proposal(&signers.get(0).unwrap(), &pid);
+}
+
+#[test]
+#[should_panic(expected = "Cannot remove: would fall below threshold")]
+fn test_remove_signer_below_threshold_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 2); // exactly at threshold
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::RemoveSigner,
+        &None, &None, &None,
+        &Some(signers.get(1).unwrap()),
+        &None,
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+}
+
+#[test]
+#[should_panic(expected = "Threshold exceeds signer count")]
+fn test_update_threshold_exceeds_signer_count_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::UpdateThreshold,
+        &None, &None, &None, &None,
+        &Some(5u32), // 5 > 3 signers
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+}
+
+#[test]
+#[should_panic(expected = "Threshold must be at least 2")]
+fn test_update_threshold_below_2_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::UpdateThreshold,
+        &None, &None, &None, &None,
+        &Some(1u32),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Already a signer")]
+fn test_add_existing_signer_panics() {
+    let env = new_env();
+    let client = make_client(&env);
+    let signers = make_signers(&env, 3);
+    client.initialize(&signers, &2u32, &86400u64);
+
+    let existing = signers.get(2).unwrap();
+    let pid = client.propose_admin_action(
+        &signers.get(0).unwrap(),
+        &AdminActionType::AddSigner,
+        &None, &None, &None,
+        &Some(existing),
+        &None,
+    );
+    client.approve_admin_action(&signers.get(1).unwrap(), &pid);
+    client.execute_admin_action(&signers.get(0).unwrap(), &pid);
+}

--- a/contracts/tests/airline_test.rs
+++ b/contracts/tests/airline_test.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{testutils::Address as _, Address, Env, Symbol, Vec};
+use soroban_sdk::{testutils::{Address as _, Ledger, LedgerInfo}, Address, Env, Symbol, Vec};
 use traqora_contracts::airline::{
     AirlineContract,
     AirlineContractClient,
@@ -7,6 +7,8 @@ use traqora_contracts::airline::{
     Flight,
     FlightInput,
     FlightStatusUpdate,
+    PricingFactors,
+    PriceUpdateInput,
 };
 
 mod common;
@@ -222,4 +224,287 @@ fn test_batch_create_flights_enforces_max_batch_size() {
     }
 
     contracts.airline.batch_create_flights(&actors.airline, &batch);
+}
+
+// ── Dynamic pricing tests ─────────────────────────────────────────────────────
+
+fn advance_ledger(env: &Env, seconds: u64) {
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp() + seconds,
+        protocol_version: env.ledger().protocol_version(),
+        sequence_number: env.ledger().sequence() + 1,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 16,
+        max_entry_ttl: 6312000,
+    });
+}
+
+#[test]
+fn test_initialize_pricing() {
+    let env = new_env();
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    register_and_verify_airline(&env, &contracts.airline, &actors.airline);
+
+    let oracle = Address::generate(&env);
+    contracts.airline.initialize_pricing(
+        &actors.admin,
+        &oracle,
+        &3600u64,       // cooldown: 1h
+        &2000i128,      // max_change_bps: 20%
+        &5000i128,      // max_demand_multiplier_bps: 50%
+    );
+}
+
+#[test]
+#[should_panic(expected = "Already initialized")]
+fn test_initialize_pricing_twice_panics() {
+    let env = new_env();
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    register_and_verify_airline(&env, &contracts.airline, &actors.airline);
+
+    let oracle = Address::generate(&env);
+    contracts.airline.initialize_pricing(&actors.admin, &oracle, &3600u64, &2000i128, &5000i128);
+    contracts.airline.initialize_pricing(&actors.admin, &oracle, &3600u64, &2000i128, &5000i128);
+}
+
+#[test]
+fn test_set_price_oracle() {
+    let env = new_env();
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    register_and_verify_airline(&env, &contracts.airline, &actors.airline);
+
+    let oracle = Address::generate(&env);
+    contracts.airline.initialize_pricing(&actors.admin, &oracle, &0u64, &2000i128, &5000i128);
+
+    let new_oracle = Address::generate(&env);
+    contracts.airline.set_price_oracle(&actors.admin, &new_oracle);
+}
+
+#[test]
+fn test_update_flight_price_within_guardrails() {
+    let env = new_env();
+    env.ledger().set_timestamp(1_000_000);
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    register_and_verify_airline(&env, &contracts.airline, &actors.airline);
+
+    let oracle = Address::generate(&env);
+    // cooldown = 0 so we can update immediately
+    contracts.airline.initialize_pricing(&actors.admin, &oracle, &0u64, &2000i128, &5000i128);
+
+    let initial_price = 100_0000000i128;
+    let flight_id = contracts.airline.create_flight(
+        &actors.airline,
+        &Symbol::new(&env, "TQ600"),
+        &Symbol::new(&env, "JFK"),
+        &Symbol::new(&env, "LHR"),
+        &2_000_000_000u64,
+        &2_000_100_000u64,
+        &200u32,
+        &initial_price,
+        &Symbol::new(&env, "USDC"),
+    );
+
+    let input = PriceUpdateInput {
+        base_price: initial_price,
+        factors: PricingFactors {
+            demand_bps: 1000i128,  // +10%
+            competitor_bps: 0i128,
+            time_to_departure_bps: 0i128,
+        },
+    };
+
+    let new_price = contracts.airline.update_flight_price(&oracle, &flight_id, &input);
+
+    // Price should increase but capped at 20% max
+    assert!(new_price > initial_price);
+    assert!(new_price <= initial_price + initial_price * 2000 / 10_000);
+
+    let flight = contracts.airline.get_flight(&flight_id).unwrap();
+    assert_eq!(flight.price, new_price);
+}
+
+#[test]
+fn test_update_flight_price_capped_at_max_change() {
+    let env = new_env();
+    env.ledger().set_timestamp(1_000_000);
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    register_and_verify_airline(&env, &contracts.airline, &actors.airline);
+
+    let oracle = Address::generate(&env);
+    contracts.airline.initialize_pricing(&actors.admin, &oracle, &0u64, &2000i128, &5000i128);
+
+    let initial_price = 100_0000000i128;
+    let flight_id = contracts.airline.create_flight(
+        &actors.airline,
+        &Symbol::new(&env, "TQ601"),
+        &Symbol::new(&env, "JFK"),
+        &Symbol::new(&env, "LHR"),
+        &2_000_000_000u64,
+        &2_000_100_000u64,
+        &200u32,
+        &initial_price,
+        &Symbol::new(&env, "USDC"),
+    );
+
+    // Request 50% increase, but cap is 20%
+    let input = PriceUpdateInput {
+        base_price: initial_price,
+        factors: PricingFactors {
+            demand_bps: 5000i128,  // +50% requested
+            competitor_bps: 0i128,
+            time_to_departure_bps: 0i128,
+        },
+    };
+
+    let new_price = contracts.airline.update_flight_price(&oracle, &flight_id, &input);
+    let expected_max = initial_price + initial_price * 2000 / 10_000; // 20% cap
+    assert_eq!(new_price, expected_max);
+}
+
+#[test]
+fn test_get_price_history() {
+    let env = new_env();
+    env.ledger().set_timestamp(1_000_000);
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    register_and_verify_airline(&env, &contracts.airline, &actors.airline);
+
+    let oracle = Address::generate(&env);
+    contracts.airline.initialize_pricing(&actors.admin, &oracle, &0u64, &2000i128, &5000i128);
+
+    let flight_id = contracts.airline.create_flight(
+        &actors.airline,
+        &Symbol::new(&env, "TQ602"),
+        &Symbol::new(&env, "JFK"),
+        &Symbol::new(&env, "LHR"),
+        &2_000_000_000u64,
+        &2_000_100_000u64,
+        &200u32,
+        &100_0000000i128,
+        &Symbol::new(&env, "USDC"),
+    );
+
+    // Empty before any updates
+    let history_before = contracts.airline.get_price_history(&flight_id);
+    assert_eq!(history_before.len(), 0);
+
+    let input = PriceUpdateInput {
+        base_price: 100_0000000i128,
+        factors: PricingFactors { demand_bps: 500i128, competitor_bps: 0i128, time_to_departure_bps: 0i128 },
+    };
+    contracts.airline.update_flight_price(&oracle, &flight_id, &input);
+
+    advance_ledger(&env, 1);
+
+    let input2 = PriceUpdateInput {
+        base_price: 100_0000000i128,
+        factors: PricingFactors { demand_bps: -500i128, competitor_bps: 0i128, time_to_departure_bps: 0i128 },
+    };
+    contracts.airline.update_flight_price(&oracle, &flight_id, &input2);
+
+    let history = contracts.airline.get_price_history(&flight_id);
+    assert_eq!(history.len(), 2);
+    assert_eq!(history.get(0).unwrap().old_price, 100_0000000i128);
+}
+
+#[test]
+fn test_get_current_price_with_demand() {
+    let env = new_env();
+    env.ledger().set_timestamp(1_000_000);
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    register_and_verify_airline(&env, &contracts.airline, &actors.airline);
+
+    let oracle = Address::generate(&env);
+    contracts.airline.initialize_pricing(&actors.admin, &oracle, &0u64, &2000i128, &5000i128);
+
+    let price = 100_0000000i128;
+    let departure = 1_000_000u64 + 24 * 3600; // 24h from now (within 48h time boost)
+    let flight_id = contracts.airline.create_flight(
+        &actors.airline,
+        &Symbol::new(&env, "TQ603"),
+        &Symbol::new(&env, "JFK"),
+        &Symbol::new(&env, "LHR"),
+        &departure,
+        &(departure + 7200),
+        &100u32,
+        &price,
+        &Symbol::new(&env, "USDC"),
+    );
+
+    let live_price = contracts.airline.get_current_price(&flight_id);
+    // Due to time boost, live price should be >= stored price
+    assert!(live_price >= price);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_update_flight_price_wrong_oracle_panics() {
+    let env = new_env();
+    env.ledger().set_timestamp(1_000_000);
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    register_and_verify_airline(&env, &contracts.airline, &actors.airline);
+
+    let oracle = Address::generate(&env);
+    contracts.airline.initialize_pricing(&actors.admin, &oracle, &0u64, &2000i128, &5000i128);
+
+    let flight_id = contracts.airline.create_flight(
+        &actors.airline,
+        &Symbol::new(&env, "TQ604"),
+        &Symbol::new(&env, "JFK"),
+        &Symbol::new(&env, "LHR"),
+        &2_000_000_000u64,
+        &2_000_100_000u64,
+        &200u32,
+        &100_0000000i128,
+        &Symbol::new(&env, "USDC"),
+    );
+
+    let wrong_oracle = Address::generate(&env);
+    let input = PriceUpdateInput {
+        base_price: 100_0000000i128,
+        factors: PricingFactors { demand_bps: 0i128, competitor_bps: 0i128, time_to_departure_bps: 0i128 },
+    };
+    contracts.airline.update_flight_price(&wrong_oracle, &flight_id, &input);
+}
+
+#[test]
+#[should_panic(expected = "Cooldown active")]
+fn test_update_flight_price_cooldown_enforced() {
+    let env = new_env();
+    env.ledger().set_timestamp(1_000_000);
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    register_and_verify_airline(&env, &contracts.airline, &actors.airline);
+
+    let oracle = Address::generate(&env);
+    contracts.airline.initialize_pricing(&actors.admin, &oracle, &3600u64, &2000i128, &5000i128);
+
+    let flight_id = contracts.airline.create_flight(
+        &actors.airline,
+        &Symbol::new(&env, "TQ605"),
+        &Symbol::new(&env, "JFK"),
+        &Symbol::new(&env, "LHR"),
+        &2_000_000_000u64,
+        &2_000_100_000u64,
+        &200u32,
+        &100_0000000i128,
+        &Symbol::new(&env, "USDC"),
+    );
+
+    let input = PriceUpdateInput {
+        base_price: 100_0000000i128,
+        factors: PricingFactors { demand_bps: 0i128, competitor_bps: 0i128, time_to_departure_bps: 0i128 },
+    };
+    contracts.airline.update_flight_price(&oracle, &flight_id, &input);
+    // Immediately try again — cooldown is 1h
+    contracts.airline.update_flight_price(&oracle, &flight_id, &input);
 }

--- a/contracts/tests/dispute_test.rs
+++ b/contracts/tests/dispute_test.rs
@@ -33,17 +33,6 @@ fn advance_ledger(env: &Env, seconds: u64) {
     });
 }
 
-// Helper function to compute commit hash
-fn compute_commit_hash(env: &Env, vote_for_passenger: bool, salt: &BytesN<32>) -> BytesN<32> {
-    let mut hash_bytes = Bytes::new(env);
-    hash_bytes.push_back(if vote_for_passenger { 1u8 } else { 0u8 });
-    let salt_bytes = salt.to_array();
-    for byte in salt_bytes.iter() {
-        hash_bytes.push_back(*byte);
-    }
-    env.crypto().keccak256(&hash_bytes).into()
-}
-
 #[test]
 fn test_initialize() {
     let env = Env::default();

--- a/contracts/tests/token_test.rs
+++ b/contracts/tests/token_test.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{String, Symbol};
+use soroban_sdk::{Env, String, Symbol};
 use traqora_contracts::token::TRQTokenContract;
 
 mod common;
@@ -142,4 +142,72 @@ fn test_transfer_from_insufficient_allowance_should_panic() {
     contracts
         .token
         .transfer_from(&actors.airline, &actors.passenger, &actors.airline, &1);
+}
+
+#[test]
+fn test_metadata_queries() {
+    let env = new_env();
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    initialize_token(&env, &contracts.token, &actors.admin);
+
+    assert_eq!(contracts.token.decimals(), 7u32);
+    assert_eq!(contracts.token.name(), String::from_str(&env, "TRQ"));
+    assert_eq!(contracts.token.symbol(), Symbol::new(&env, "TRQ"));
+    assert_eq!(contracts.token.total_supply(), 0);
+}
+
+#[test]
+fn test_total_supply_tracks_mints() {
+    let env = new_env();
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    initialize_token(&env, &contracts.token, &actors.admin);
+
+    contracts.token.mint(&actors.admin, &actors.passenger, &1000);
+    contracts.token.mint(&actors.admin, &actors.airline, &500);
+    assert_eq!(contracts.token.total_supply(), 1500);
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_mint_by_non_admin_panics() {
+    // With mock_all_auths, auth passes but the admin check fails
+    let env = new_env();
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    initialize_token(&env, &contracts.token, &actors.admin);
+
+    // passenger is authorized via mock but is not the stored admin
+    contracts.token.mint(&actors.passenger, &actors.passenger, &1000);
+}
+
+#[test]
+fn test_allowance_expired_returns_zero() {
+    use soroban_sdk::testutils::{Ledger, LedgerInfo};
+
+    let env = new_env();
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    initialize_token(&env, &contracts.token, &actors.admin);
+
+    contracts.token.mint(&actors.admin, &actors.passenger, &500);
+    // Approve with expiration at ledger sequence 1
+    contracts.token.approve(&actors.passenger, &actors.airline, &300, &1u32);
+    assert_eq!(contracts.token.allowance(&actors.passenger, &actors.airline), 300);
+
+    // Advance ledger sequence past expiration
+    env.ledger().set(LedgerInfo {
+        timestamp: 0,
+        protocol_version: env.ledger().protocol_version(),
+        sequence_number: 2, // past expiration_ledger=1
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 16,
+        max_entry_ttl: 6312000,
+    });
+
+    // Expired allowance should read as 0
+    assert_eq!(contracts.token.allowance(&actors.passenger, &actors.airline), 0);
 }


### PR DESCRIPTION
Closes #69 

## Summary
- Adds 36 admin multisig tests (was an empty placeholder file) covering all 7 action types, threshold enforcement, expiry, cancellation, and unauthorized-access negative cases
- Adds 9 airline dynamic pricing tests for `initialize_pricing`, `update_flight_price` (cap enforcement, cooldown, wrong oracle), `get_price_history`, and `get_current_price`
- Adds 4 token edge-case tests: metadata queries, non-admin mint rejection, expired allowance
- Fixes 3 merge conflicts (`dispute/lib.rs`, `storage_version/lib.rs`) and adds missing `PriceUpdateInput` struct
- Fixes booking ID collision bug (timestamp → counter) and adds missing oracle methods to booking contract
- Total: **149 tests, all green**

## Test plan
- [ ] `cd contracts && cargo test` — all 149 tests pass
- [ ] `cargo build --target wasm32-unknown-unknown --release` — contracts compile to WASM
- [ ] CI `cargo test` step runs on every PR (already configured in `.github/workflows/ci.yml`)
