### PR TITLE
feat(contracts): add 48h timelock for Soroban WASM upgrades (#67)

### DIFF
--- a/contracts/src/admin/lib.rs
+++ b/contracts/src/admin/lib.rs
@@ -1,5 +1,6 @@
 use soroban_sdk::{
-    contract, contractimpl, contractmeta, contracttype, symbol_short, Address, Env, Symbol, Vec,
+    contract, contractimpl, contractmeta, contracttype, symbol_short, Address, BytesN, Env, Symbol,
+    Vec,
 };
 
 // Contract metadata
@@ -475,5 +476,16 @@ impl AdminMultisig {
         } else {
             false
         }
+    }
+
+    pub fn schedule_upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        let config = AdminStorage::get_multisig_config(&env).expect("Not initialized");
+        assert!(Self::is_signer(&config, &admin), "Unauthorized");
+        crate::upgrade_timelock::schedule_upgrade_authorized(&env, new_wasm_hash);
+    }
+
+    pub fn execute_upgrade(env: Env) {
+        crate::upgrade_timelock::execute_scheduled_upgrade(&env);
     }
 }

--- a/contracts/src/airline/lib.rs
+++ b/contracts/src/airline/lib.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, vec, Address, Env, Symbol, Vec,
+    contract, contractimpl, contracttype, symbol_short, vec, Address, BytesN, Env, Symbol, Vec,
 };
 
 #[contracttype]
@@ -643,5 +643,16 @@ impl AirlineContract {
             .checked_mul(demand_multiplier_bps)
             .expect("Math overflow")
             / 10_000i128
+    }
+
+    pub fn schedule_upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        let cfg = PricingStorage::get_config(&env).expect("Not initialized");
+        assert!(cfg.admin == admin, "Unauthorized");
+        crate::upgrade_timelock::schedule_upgrade_authorized(&env, new_wasm_hash);
+    }
+
+    pub fn execute_upgrade(env: Env) {
+        crate::upgrade_timelock::execute_scheduled_upgrade(&env);
     }
 }

--- a/contracts/src/booking/lib.rs
+++ b/contracts/src/booking/lib.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec, token};
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol, Vec, token,
+};
 
 #[contracttype]
 #[derive(Clone)]
@@ -303,5 +305,23 @@ impl BookingContract {
             failures,
             total_released,
         }
+    }
+
+    pub fn init_upgrade_owner(env: Env, admin: Address) {
+        admin.require_auth();
+        crate::upgrade_timelock::try_init_upgrade_owner(&env, admin);
+    }
+
+    pub fn schedule_upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        assert!(
+            crate::upgrade_timelock::get_upgrade_owner(&env).as_ref() == Some(&admin),
+            "Unauthorized"
+        );
+        crate::upgrade_timelock::schedule_upgrade_authorized(&env, new_wasm_hash);
+    }
+
+    pub fn execute_upgrade(env: Env) {
+        crate::upgrade_timelock::execute_scheduled_upgrade(&env);
     }
 }

--- a/contracts/src/dispute/lib.rs
+++ b/contracts/src/dispute/lib.rs
@@ -784,4 +784,22 @@ impl DisputeContract {
     pub fn get_config(env: Env) -> Option<DisputeConfig> {
         DisputeStorageKey::get_config(&env)
     }
+
+    pub fn init_upgrade_owner(env: Env, admin: Address) {
+        admin.require_auth();
+        crate::upgrade_timelock::try_init_upgrade_owner(&env, admin);
+    }
+
+    pub fn schedule_upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        assert!(
+            crate::upgrade_timelock::get_upgrade_owner(&env).as_ref() == Some(&admin),
+            "Unauthorized"
+        );
+        crate::upgrade_timelock::schedule_upgrade_authorized(&env, new_wasm_hash);
+    }
+
+    pub fn execute_upgrade(env: Env) {
+        crate::upgrade_timelock::execute_scheduled_upgrade(&env);
+    }
 }

--- a/contracts/src/governance/lib.rs
+++ b/contracts/src/governance/lib.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol};
 
 #[contracttype]
 #[derive(Clone)]
@@ -383,5 +383,23 @@ impl GovernanceContract {
 
     pub fn get_vote_record(env: Env, voter: Address, proposal_id: u64) -> Option<Vote> {
         GovernanceStorageKey::get_vote_record(&env, &voter, proposal_id)
+    }
+
+    pub fn init_upgrade_owner(env: Env, admin: Address) {
+        admin.require_auth();
+        crate::upgrade_timelock::try_init_upgrade_owner(&env, admin);
+    }
+
+    pub fn schedule_upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        assert!(
+            crate::upgrade_timelock::get_upgrade_owner(&env).as_ref() == Some(&admin),
+            "Unauthorized"
+        );
+        crate::upgrade_timelock::schedule_upgrade_authorized(&env, new_wasm_hash);
+    }
+
+    pub fn execute_upgrade(env: Env) {
+        crate::upgrade_timelock::execute_scheduled_upgrade(&env);
     }
 }

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -32,3 +32,5 @@ pub mod oracle;
 
 #[path = "admin/lib.rs"]
 pub mod admin;
+
+pub mod upgrade_timelock;

--- a/contracts/src/loyalty/lib.rs
+++ b/contracts/src/loyalty/lib.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol};
 
 #[contracttype]
 #[derive(Clone)]
@@ -210,5 +210,23 @@ impl LoyaltyContract {
 
     pub fn get_tier_benefits(env: Env, tier: Symbol) -> Option<TierConfig> {
         LoyaltyStorageKey::get_tier_config(&env, &tier)
+    }
+
+    pub fn init_upgrade_owner(env: Env, admin: Address) {
+        admin.require_auth();
+        crate::upgrade_timelock::try_init_upgrade_owner(&env, admin);
+    }
+
+    pub fn schedule_upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        assert!(
+            crate::upgrade_timelock::get_upgrade_owner(&env).as_ref() == Some(&admin),
+            "Unauthorized"
+        );
+        crate::upgrade_timelock::schedule_upgrade_authorized(&env, new_wasm_hash);
+    }
+
+    pub fn execute_upgrade(env: Env) {
+        crate::upgrade_timelock::execute_scheduled_upgrade(&env);
     }
 }

--- a/contracts/src/oracle/lib.rs
+++ b/contracts/src/oracle/lib.rs
@@ -103,6 +103,17 @@ pub struct FlightOracle;
 
 #[contractimpl]
 impl FlightOracle {
+    pub fn schedule_upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        let cfg = OracleStorage::get_config(&env).expect("Not initialized");
+        assert!(cfg.admin == admin, "Unauthorized");
+        crate::upgrade_timelock::schedule_upgrade_authorized(&env, new_wasm_hash);
+    }
+
+    pub fn execute_upgrade(env: Env) {
+        crate::upgrade_timelock::execute_scheduled_upgrade(&env);
+    }
+
     pub fn initialize(
         env: Env,
         admin: Address,

--- a/contracts/src/proxy/lib.rs
+++ b/contracts/src/proxy/lib.rs
@@ -422,6 +422,17 @@ impl ContractProxy {
         config.state == ProxyState::Upgrading
     }
 
+    pub fn schedule_upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        let config = ProxyStorage::get_config(&env).expect("Not initialized");
+        assert!(config.admin == admin, "Unauthorized");
+        crate::upgrade_timelock::schedule_upgrade_authorized(&env, new_wasm_hash);
+    }
+
+    pub fn execute_upgrade(env: Env) {
+        crate::upgrade_timelock::execute_scheduled_upgrade(&env);
+    }
+
     fn is_signer(multisig: &MultisigConfig, address: &Address) -> bool {
         for signer in multisig.signers.iter() {
             if signer == *address {

--- a/contracts/src/refund/lib.rs
+++ b/contracts/src/refund/lib.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Symbol};
 
 #[contracttype]
 #[derive(Clone)]
@@ -168,5 +168,23 @@ impl RefundContract {
             // No refund
             0
         }
+    }
+
+    pub fn init_upgrade_owner(env: Env, admin: Address) {
+        admin.require_auth();
+        crate::upgrade_timelock::try_init_upgrade_owner(&env, admin);
+    }
+
+    pub fn schedule_upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        assert!(
+            crate::upgrade_timelock::get_upgrade_owner(&env).as_ref() == Some(&admin),
+            "Unauthorized"
+        );
+        crate::upgrade_timelock::schedule_upgrade_authorized(&env, new_wasm_hash);
+    }
+
+    pub fn execute_upgrade(env: Env) {
+        crate::upgrade_timelock::execute_scheduled_upgrade(&env);
     }
 }

--- a/contracts/src/token/lib.rs
+++ b/contracts/src/token/lib.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env, String, Symbol,
+    contract, contractimpl, contracttype, symbol_short, Address, BytesN, Env, String, Symbol,
 };
 
 // TRQ Token - Traqora Governance and Loyalty Token
@@ -225,5 +225,18 @@ impl TRQTokenContract {
         TokenStorage::get_metadata(&env)
             .map(|m| m.symbol)
             .expect("Not initialized")
+    }
+
+    pub fn schedule_upgrade(env: Env, admin: Address, new_wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        assert!(
+            TokenStorage::get_admin(&env).as_ref() == Some(&admin),
+            "Unauthorized"
+        );
+        crate::upgrade_timelock::schedule_upgrade_authorized(&env, new_wasm_hash);
+    }
+
+    pub fn execute_upgrade(env: Env) {
+        crate::upgrade_timelock::execute_scheduled_upgrade(&env);
     }
 }

--- a/contracts/src/upgrade_timelock.rs
+++ b/contracts/src/upgrade_timelock.rs
@@ -1,0 +1,67 @@
+//! Shared 48-hour timelock for Soroban `update_current_contract_wasm` upgrades.
+
+use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, Symbol};
+
+#[contracttype]
+#[derive(Clone)]
+pub struct ScheduledUpgrade {
+    pub wasm_hash: BytesN<32>,
+    pub scheduled_at: u64,
+}
+
+/// Delay between `schedule_upgrade` and allowed `execute_upgrade` (48 hours).
+pub const TIMELOCK_SECS: u64 = 48 * 60 * 60;
+
+pub fn get_scheduled_upgrade(env: &Env) -> Option<ScheduledUpgrade> {
+    env.storage()
+        .instance()
+        .get(&symbol_short!("upg_pend"))
+}
+
+pub fn schedule_upgrade_authorized(env: &Env, new_wasm_hash: BytesN<32>) {
+    let scheduled_at = env.ledger().timestamp();
+    let record = ScheduledUpgrade {
+        wasm_hash: new_wasm_hash.clone(),
+        scheduled_at,
+    };
+    env.storage()
+        .instance()
+        .set(&symbol_short!("upg_pend"), &record);
+    let executable_after = scheduled_at.saturating_add(TIMELOCK_SECS);
+    env.events().publish(
+        (Symbol::new(env, "UpgradeScheduled"),),
+        (new_wasm_hash, scheduled_at, executable_after),
+    );
+}
+
+pub fn execute_scheduled_upgrade(env: &Env) {
+    let record = get_scheduled_upgrade(env).expect("No scheduled upgrade");
+    let now = env.ledger().timestamp();
+    assert!(
+        now >= record.scheduled_at.saturating_add(TIMELOCK_SECS),
+        "Timelock active"
+    );
+    let hash = record.wasm_hash.clone();
+    env.deployer().update_current_contract_wasm(hash.clone());
+    env.storage()
+        .instance()
+        .remove(&symbol_short!("upg_pend"));
+    env.events()
+        .publish((Symbol::new(env, "UpgradeExecuted"),), hash);
+}
+
+pub fn get_upgrade_owner(env: &Env) -> Option<Address> {
+    env.storage()
+        .instance()
+        .get(&symbol_short!("up_owner"))
+}
+
+pub fn try_init_upgrade_owner(env: &Env, owner: Address) {
+    assert!(
+        get_upgrade_owner(env).is_none(),
+        "Upgrade owner already set"
+    );
+    env.storage()
+        .instance()
+        .set(&symbol_short!("up_owner"), &owner);
+}

--- a/contracts/tests/upgrade_timelock_test.rs
+++ b/contracts/tests/upgrade_timelock_test.rs
@@ -1,0 +1,71 @@
+use soroban_sdk::{testutils::Address as _, vec, Address, BytesN, Env, String, Symbol};
+use traqora_contracts::booking::{BookingContract, BookingContractClient};
+use traqora_contracts::proxy::{ContractProxy, ContractProxyClient};
+use traqora_contracts::token::{TRQTokenContract, TRQTokenContractClient};
+
+fn dummy_wasm_hash(env: &Env, byte: u8) -> BytesN<32> {
+    BytesN::from_array(env, &[byte; 32])
+}
+
+#[test]
+#[should_panic(expected = "Timelock active")]
+fn upgrade_timelock_premature_execute_rejected_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TRQTokenContract, ());
+    let client = TRQTokenContractClient::new(&env, &contract_id);
+    client.init_token(
+        &admin,
+        &String::from_str(&env, "TRQ"),
+        &Symbol::new(&env, "TRQ"),
+        &7,
+    );
+    client.schedule_upgrade(&admin, &dummy_wasm_hash(&env, 1));
+    client.execute_upgrade();
+}
+
+#[test]
+#[should_panic(expected = "Timelock active")]
+fn upgrade_timelock_premature_execute_rejected_booking() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(BookingContract, ());
+    let client = BookingContractClient::new(&env, &contract_id);
+    client.init_upgrade_owner(&admin);
+    client.schedule_upgrade(&admin, &dummy_wasm_hash(&env, 2));
+    client.execute_upgrade();
+}
+
+#[test]
+#[should_panic(expected = "Timelock active")]
+fn upgrade_timelock_premature_execute_rejected_proxy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let implementation = dummy_wasm_hash(&env, 3);
+    let signers = vec![&env, admin.clone()];
+    let contract_id = env.register(ContractProxy, ());
+    let client = ContractProxyClient::new(&env, &contract_id);
+    client.init_proxy(&admin, &implementation, &signers, &1u32);
+    client.schedule_upgrade(&admin, &dummy_wasm_hash(&env, 4));
+    client.execute_upgrade();
+}
+
+#[test]
+#[should_panic(expected = "No scheduled upgrade")]
+fn upgrade_execute_without_schedule_rejected_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(TRQTokenContract, ());
+    let client = TRQTokenContractClient::new(&env, &contract_id);
+    client.init_token(
+        &admin,
+        &String::from_str(&env, "TRQ"),
+        &Symbol::new(&env, "TRQ"),
+        &7,
+    );
+    client.execute_upgrade();
+}


### PR DESCRIPTION
Introduce shared upgrade_timelock module with schedule_upgrade (admin-gated), execute_upgrade after 48 hours, and UpgradeScheduled / UpgradeExecuted events. Wire entrypoints across deployable contracts; add init_upgrade_owner where no admin existed. Add tests for premature execute and missing schedule.

closes #67 