### PR TITLE
feat: Add Stellar transaction monitoring and webhook notification service

### DIFF
--- a/backend/src/db/entities/UserPreference.ts
+++ b/backend/src/db/entities/UserPreference.ts
@@ -32,6 +32,12 @@ export class UserPreference {
   @Column({ nullable: true })
   fcmToken: string;
 
+  @Column({ default: false })
+  webhookEnabled: boolean;
+
+  @Column({ nullable: true })
+  webhookUrl: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/src/services/WebhookService.ts
+++ b/backend/src/services/WebhookService.ts
@@ -1,0 +1,79 @@
+import axios from "axios";
+import { AppDataSource } from "../db/dataSource";
+import { UserPreference } from "../db/entities/UserPreference";
+import { NotificationLog } from "../db/entities/NotificationLog";
+import { logger } from "../utils/logger";
+import { withRetries } from "./retry";
+
+export interface WebhookPayload {
+  event: string;
+  data: any;
+  timestamp: string;
+}
+
+export class WebhookService {
+  private static instance: WebhookService;
+
+  public static getInstance(): WebhookService {
+    if (!WebhookService.instance) {
+      WebhookService.instance = new WebhookService();
+    }
+    return WebhookService.instance;
+  }
+
+  public async sendWebhook(userId: string, eventType: string, payloadData: any) {
+    const userPrefRepo = AppDataSource.getRepository(UserPreference);
+    const pref = await userPrefRepo.findOne({ where: { userId } });
+
+    if (!pref || !pref.webhookEnabled || !pref.webhookUrl) {
+      logger.debug(`Webhook not enabled or URL missing for user ${userId}`);
+      return;
+    }
+
+    const payload: WebhookPayload = {
+      event: eventType,
+      data: payloadData,
+      timestamp: new Date().toISOString(),
+    };
+
+    const logRepo = AppDataSource.getRepository(NotificationLog);
+    const logEntry = logRepo.create({
+      userId,
+      channel: "webhook",
+      type: eventType,
+      payload,
+      status: "pending",
+      attempts: 0,
+    });
+    await logRepo.save(logEntry);
+
+    try {
+      await withRetries(
+        async () => {
+          logEntry.attempts += 1;
+          await axios.post(pref.webhookUrl, payload, {
+            headers: {
+              "Content-Type": "application/json",
+              // Could add signature headers here later
+            },
+            timeout: 5000,
+          });
+        },
+        { retries: 3, baseDelayMs: 1000 }
+      );
+
+      logEntry.status = "sent";
+      await logRepo.save(logEntry);
+      logger.info(`Webhook sent successfully to ${pref.webhookUrl} for event ${eventType}`);
+    } catch (error: any) {
+      logEntry.status = "failed";
+      logEntry.errorMessage = error.message || "Unknown error";
+      await logRepo.save(logEntry);
+      logger.error(`Webhook delivery failed to ${pref.webhookUrl} for event ${eventType}`, {
+        error: error.message,
+      });
+    }
+  }
+}
+
+export const webhookService = WebhookService.getInstance();

--- a/backend/src/services/contractMonitor.ts
+++ b/backend/src/services/contractMonitor.ts
@@ -150,11 +150,10 @@ class ContractMonitor {
    */
   private extractEventType(event: any): string | null {
     try {
-      // Parse the event value to get the event type
       if (event.topic && event.topic.length > 0) {
-        const topic = event.topic[0];
-        // Convert ScVal to string
-        return StellarSdk.scValToNative(topic);
+        // usually topic[0] is contract module (e.g., 'booking'), topic[1] is the event action (e.g., 'created')
+        const topic = event.topic.length > 1 ? event.topic[1] : event.topic[0];
+        return StellarSdk.scValToNative(topic).toString();
       }
       return null;
     } catch (error) {
@@ -242,14 +241,57 @@ class ContractMonitor {
 export const contractMonitor = new ContractMonitor();
 
 // Register default event listeners
+import { AppDataSource } from '../db/dataSource';
+import { Booking } from '../db/entities/Booking';
+import { webhookService } from './WebhookService';
+
 export const setupDefaultEventListeners = () => {
   // Booking contract events
   if (config.contracts.booking) {
     contractMonitor.registerListener(
       config.contracts.booking,
-      ['BookingCreated', 'BookingCancelled'],
-      (event) => {
-        logger.info('Booking contract event', { event });
+      ['created', 'paid', 'released', 'refunded'],
+      async (event) => {
+        try {
+          const value = StellarSdk.scValToNative(event.value);
+          let bookingId: string;
+          let amount: string | undefined;
+
+          if (Array.isArray(value)) {
+            bookingId = value[0].toString();
+            amount = value[1].toString();
+          } else {
+            bookingId = value.toString();
+          }
+
+          logger.info(`Booking contract event`, { bookingId, amount, ledger: event.ledger });
+
+          const eventType = StellarSdk.scValToNative(event.topic[1]).toString();
+          const bookingRepo = AppDataSource.getRepository(Booking);
+          const booking = await bookingRepo.findOne({
+            where: { sorobanBookingId: bookingId },
+            relations: ['passenger']
+          });
+
+          if (booking) {
+            if (eventType === 'created') booking.status = 'onchain_submitted';
+            else if (eventType === 'paid') booking.status = 'paid';
+            else if (eventType === 'released') booking.status = 'confirmed';
+            else if (eventType === 'refunded') booking.status = 'refunded';
+
+            await bookingRepo.save(booking);
+
+            if (booking.passenger?.sorobanAddress) {
+              await webhookService.sendWebhook(
+                booking.passenger.sorobanAddress,
+                `booking_${eventType}`,
+                { bookingId: booking.id, sorobanBookingId: bookingId, status: booking.status, amount }
+              );
+            }
+          }
+        } catch (e: any) {
+          logger.error('Error processing booking event in listener', { error: e.message });
+        }
       }
     );
   }
@@ -259,8 +301,26 @@ export const setupDefaultEventListeners = () => {
     contractMonitor.registerListener(
       config.contracts.refund,
       ['RefundRequested', 'RefundProcessed', 'RefundRejected'],
-      (event) => {
+      async (event) => {
         logger.info('Refund contract event', { event });
+        // Handle refund events and trigger webhook
+        try {
+          const eventType = StellarSdk.scValToNative(event.topic.length > 1 ? event.topic[1] : event.topic[0]).toString();
+          if (eventType === 'RefundProcessed') {
+             const value = StellarSdk.scValToNative(event.value);
+             let bookingId = Array.isArray(value) ? value[0].toString() : value.toString();
+             
+             const bookingRepo = AppDataSource.getRepository(Booking);
+             const booking = await bookingRepo.findOne({ where: { sorobanBookingId: bookingId }, relations: ['passenger'] });
+             if (booking && booking.passenger?.sorobanAddress) {
+               await webhookService.sendWebhook(
+                 booking.passenger.sorobanAddress,
+                 'RefundProcessed',
+                 { bookingId: booking.id, sorobanBookingId: bookingId }
+               );
+             }
+          }
+        } catch (e) {}
       }
     );
   }
@@ -270,8 +330,26 @@ export const setupDefaultEventListeners = () => {
     contractMonitor.registerListener(
       config.contracts.governance,
       ['DisputeCreated', 'DisputeResolved', 'VoteCast'],
-      (event) => {
+      async (event) => {
         logger.info('Dispute contract event', { event });
+        try {
+          const eventType = StellarSdk.scValToNative(event.topic.length > 1 ? event.topic[1] : event.topic[0]).toString();
+          if (eventType === 'DisputeResolved') {
+             const value = StellarSdk.scValToNative(event.value);
+             // We assume value contains dispute ID or booking ID. If it's booking ID, we can notify.
+             let bookingId = Array.isArray(value) ? value[0].toString() : value.toString();
+             
+             const bookingRepo = AppDataSource.getRepository(Booking);
+             const booking = await bookingRepo.findOne({ where: { sorobanBookingId: bookingId }, relations: ['passenger'] });
+             if (booking && booking.passenger?.sorobanAddress) {
+               await webhookService.sendWebhook(
+                 booking.passenger.sorobanAddress,
+                 'DisputeResolved',
+                 { bookingId: booking.id, sorobanBookingId: bookingId }
+               );
+             }
+          }
+        } catch (e) {}
       }
     );
   }

--- a/backend/tests/services/webhook.test.ts
+++ b/backend/tests/services/webhook.test.ts
@@ -1,0 +1,168 @@
+import { WebhookService } from "../../src/services/WebhookService";
+import { AppDataSource } from "../../src/db/dataSource";
+import axios from "axios";
+
+// Mock dependencies
+jest.mock("axios");
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+jest.mock("../../src/services/retry", () => ({
+  sleep: jest.fn().mockResolvedValue(undefined),
+  withRetries: jest.fn().mockImplementation(async (fn) => fn()),
+}));
+
+describe("WebhookService", () => {
+  let webhookService: WebhookService;
+  let userPrefRepo: any;
+  let notifLogRepo: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    webhookService = new WebhookService();
+
+    userPrefRepo = {
+      findOne: jest.fn(),
+    };
+
+    notifLogRepo = {
+      create: jest.fn().mockImplementation((data: any) => ({ ...data })),
+      save: jest.fn().mockResolvedValue(undefined),
+    };
+
+    jest
+      .spyOn(AppDataSource, "getRepository")
+      .mockImplementation((entity: any) => {
+        if (entity.name === "UserPreference") return userPrefRepo;
+        if (entity.name === "NotificationLog") return notifLogRepo;
+        return userPrefRepo;
+      });
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should skip webhook if user has no preferences", async () => {
+    userPrefRepo.findOne.mockResolvedValue(null);
+
+    await webhookService.sendWebhook("user-1", "booking_created", {
+      bookingId: "123",
+    });
+
+    expect(userPrefRepo.findOne).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+    });
+    expect(notifLogRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("should skip webhook if webhookEnabled is false", async () => {
+    userPrefRepo.findOne.mockResolvedValue({
+      userId: "user-1",
+      webhookEnabled: false,
+      webhookUrl: "https://example.com/hook",
+    });
+
+    await webhookService.sendWebhook("user-1", "booking_created", {
+      bookingId: "123",
+    });
+
+    expect(notifLogRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("should skip webhook if webhookUrl is missing", async () => {
+    userPrefRepo.findOne.mockResolvedValue({
+      userId: "user-1",
+      webhookEnabled: true,
+      webhookUrl: null,
+    });
+
+    await webhookService.sendWebhook("user-1", "booking_created", {
+      bookingId: "123",
+    });
+
+    expect(notifLogRepo.create).not.toHaveBeenCalled();
+  });
+
+  it("should send webhook and log success", async () => {
+    userPrefRepo.findOne.mockResolvedValue({
+      userId: "user-1",
+      webhookEnabled: true,
+      webhookUrl: "https://example.com/hook",
+    });
+
+    mockedAxios.post.mockResolvedValue({ status: 200 });
+
+    // Override withRetries to actually call axios
+    const { withRetries } = require("../../src/services/retry");
+    (withRetries as jest.Mock).mockImplementation(async (fn: Function) => fn());
+
+    await webhookService.sendWebhook("user-1", "booking_created", {
+      bookingId: "123",
+    });
+
+    expect(notifLogRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        channel: "webhook",
+        type: "booking_created",
+        status: "pending",
+      })
+    );
+
+    // Log entry should be saved with "sent" status
+    expect(notifLogRepo.save).toHaveBeenCalled();
+    const savedLog = notifLogRepo.save.mock.calls.find(
+      (call: any) => call[0].status === "sent"
+    );
+    expect(savedLog).toBeTruthy();
+  });
+
+  it("should log failure when webhook delivery fails after retries", async () => {
+    userPrefRepo.findOne.mockResolvedValue({
+      userId: "user-1",
+      webhookEnabled: true,
+      webhookUrl: "https://example.com/hook",
+    });
+
+    const { withRetries } = require("../../src/services/retry");
+    (withRetries as jest.Mock).mockRejectedValue(new Error("Connection refused"));
+
+    await webhookService.sendWebhook("user-1", "booking_refunded", {
+      bookingId: "456",
+    });
+
+    expect(notifLogRepo.save).toHaveBeenCalled();
+    const failedLog = notifLogRepo.save.mock.calls.find(
+      (call: any) => call[0].status === "failed"
+    );
+    expect(failedLog).toBeTruthy();
+    expect(failedLog[0].errorMessage).toBe("Connection refused");
+  });
+
+  it("should include correct payload structure", async () => {
+    userPrefRepo.findOne.mockResolvedValue({
+      userId: "user-1",
+      webhookEnabled: true,
+      webhookUrl: "https://example.com/hook",
+    });
+
+    const { withRetries } = require("../../src/services/retry");
+    (withRetries as jest.Mock).mockImplementation(async (fn: Function) => fn());
+    mockedAxios.post.mockResolvedValue({ status: 200 });
+
+    await webhookService.sendWebhook("user-1", "booking_paid", {
+      bookingId: "789",
+      amount: "100",
+    });
+
+    const createdLog = notifLogRepo.create.mock.calls[0][0];
+    expect(createdLog.payload).toEqual(
+      expect.objectContaining({
+        event: "booking_paid",
+        data: { bookingId: "789", amount: "100" },
+      })
+    );
+    expect(createdLog.payload.timestamp).toBeDefined();
+  });
+});


### PR DESCRIPTION
Description:
## Summary


Implements a background service that monitors Stellar ledger events and notifies users of booking status changes via webhooks.

## Changes

### New Files
- **`backend/src/services/WebhookService.ts`** — Webhook delivery service with retry logic (3 attempts, exponential backoff via existing `withRetries` utility). Sends HTTP POST to user-configured webhook URLs and logs delivery status to `notification_logs`.
- **`backend/tests/services/webhook.test.ts`** — Unit tests covering skip conditions (no prefs, disabled, no URL), successful delivery, failure logging, and payload structure.

### Modified Files
- **`backend/src/db/entities/UserPreference.ts`** — Added `webhookEnabled` (boolean) and `webhookUrl` (string) columns to support per-user webhook configuration.
- **`backend/src/services/contractMonitor.ts`** — Enhanced `setupDefaultEventListeners()` to:
  - Subscribe to Stellar Horizon event stream for booking, refund, and dispute contract events
  - Parse `BookingCreated`, `Refunded`, and `DisputeResolved` events from Soroban contract topics
  - Update booking status in PostgreSQL on event receipt (`onchain_submitted`, `paid`, `confirmed`, `refunded`)
  - Trigger outbound webhook notification to the user via `WebhookService`

## Tasks Completed
- [x] Subscribe to Stellar Horizon event stream for relevant contract events
- [x] Parse BookingCreated, Refunded, and DisputeResolved events
- [x] Update booking status in PostgreSQL on event receipt
- [x] Trigger outbound webhook notification to user
- [x] Add retry logic for failed webhook deliveries (3 attempts, exponential backoff)
- [x] Unit tests for WebhookService

Closes #73