### PR TITLE
feat(backend): centralized error handling, retries, and graceful degradation

### DIFF
--- a/backend/docs/error-recovery-guide.md
+++ b/backend/docs/error-recovery-guide.md
@@ -1,0 +1,74 @@
+# Error Recovery Guide
+
+This guide defines recovery actions for transient and partial failures in the Traqora backend.
+
+## Standard API Error Contract
+
+All middleware-driven failures return this envelope:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable summary",
+    "retryable": true,
+    "retryAfterMs": 15000,
+    "requestId": "1714090000000-ab12cd",
+    "timestamp": "2026-04-26T10:00:00.000Z",
+    "details": {}
+  }
+}
+```
+
+## Retry and Circuit Breaker Policy
+
+- External calls use exponential backoff retries.
+- Circuit opens after 5 consecutive failures.
+- When open, API responds with `503` and `code: CIRCUIT_OPEN`.
+- Retry delayed until `retryAfterMs` expires.
+
+## Incident Playbook
+
+### 1) Stellar/Soroban timeouts
+
+1. Confirm error code frequency from logs (`external_operation_failed`, `circuit_opened`).
+2. Validate RPC endpoint health independently.
+3. Keep circuit open until endpoint recovers (automatic half-open probe is enabled).
+4. Verify successful close event (`circuit_closed`) and resumed transaction flow.
+
+### 2) Payment processor 5xx errors
+
+1. Confirm `stripe_create_refund` failures in logs.
+2. Observe retry attempts (`retrying_operation`).
+3. If failures persist, circuit opens and prevents hot-looping.
+4. Reconcile pending refunds after recovery by replaying failed refund jobs.
+
+### 3) Partial failure in booking workflow (seat reserved, blockchain submit fails)
+
+1. Detect failed booking state (`status=failed`, `lastError` set).
+2. Ensure seat compensation happened (`seatsAvailable` incremented).
+3. Re-run booking only with a new idempotency key after user confirmation.
+4. Audit by `requestId`, `bookingId`, and `sorobanTxHash` fields.
+
+## Safe Rollback Actions
+
+- Safe: disable traffic to unstable dependency, wait for circuit cooldown.
+- Safe: replay idempotent operations with a new correlation id.
+- Safe: verify compensation updates before retrying user action.
+- Unsafe: direct manual DB mutation of booking/refund status without audit entry.
+
+## Logging and Alerts
+
+All failures should include:
+
+- `requestId`
+- `operation`
+- `userId` (or `anonymous`)
+- timestamped structured payload
+
+Create alerts for:
+
+- repeated `circuit_opened` events in 5 minutes
+- >3 retries per operation with no success
+- booking/refund stuck in transitional states (`onchain_submitted`, `processing`) beyond SLO

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -164,10 +164,15 @@ export const createApp = (options: AppOptions = {}) => {
   app.use(errorHandler);
 
   app.use((_req, res) => {
+    const requestId = String(res.locals.requestId || 'unknown');
     res.status(404).json({
+      success: false,
       error: {
         code: 'NOT_FOUND',
         message: 'Endpoint not found',
+        retryable: false,
+        requestId,
+        timestamp: new Date().toISOString(),
       },
     });
   });

--- a/backend/src/db/entities/Flight.ts
+++ b/backend/src/db/entities/Flight.ts
@@ -22,7 +22,7 @@ export class Flight {
   @Column({ type: process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamptz' })
   departureTime!: Date;
 
-  @Column({ type: 'timestamptz', nullable: true })
+  @Column({ type: process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamptz', nullable: true })
   arrivalTime?: Date;
 
   @Column({ type: 'integer', default: 0 })
@@ -56,7 +56,7 @@ export class Flight {
   dataSource!: string; // AMADEUS, AIRLINE_API, MANUAL, etc.
 
   @Index()
-  @Column({ type: 'timestamptz', nullable: true })
+  @Column({ type: process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamptz', nullable: true })
   lastSyncedAt?: Date;
 
   @Column({ type: 'varchar', length: 32, default: 'EXACT_MATCH' })
@@ -72,10 +72,10 @@ export class Flight {
   lastSyncError?: string;
 
   // Audit
-  @CreateDateColumn({ type: 'timestamptz' })
+  @CreateDateColumn({ type: process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamptz' })
   createdAt!: Date;
 
-  @UpdateDateColumn({ type: 'timestamptz' })
+  @UpdateDateColumn({ type: process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamptz' })
   updatedAt!: Date;
 
   @Column({ type: 'jsonb', nullable: true })

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,142 +1,24 @@
+import http from 'http';
+import dotenv from 'dotenv';
 import { createApp } from './app';
 import { config } from './config';
 import { logger } from './utils/logger';
-import { errorHandler } from './utils/errorHandler';
-// import { rateLimiter } from './utils/rateLimiter';
 import { initDataSource } from './db/dataSource';
-import { AppDataSource } from './db/dataSource';
-
-// Route imports
-import { flightRoutes } from './api/routes/flights';
-import { subscriptionRoutes } from './api/routes/subscriptions';
-import { governanceRoutes } from './api/routes/governance';
-import { bookingRoutes } from './api/routes/bookings';
-import { metricsRoutes } from './api/routes/metrics';
-// import { airlineRoutes } from './api/routes/airlines';
-// import { userRoutes } from './api/routes/users';
-// import { refundRoutes } from './api/routes/refunds';
-// import { loyaltyRoutes } from './api/routes/loyalty';
-// import { walletRoutes } from './api/routes/wallet';
-
-// New Services
-import { connectDatabase } from './config/database';
-import { initWebSocket, getWebSocketServer } from './websockets/server';
+import { initWebSocket } from './websockets/server';
 import { initPriceMonitorCron } from './jobs/priceMonitor';
-
-// Monitoring
-import { metricsMiddleware } from './middleware/metricsMiddleware';
-import { requestLogger } from './middleware/requestLogger';
-import { contractMonitor, setupDefaultEventListeners, startWalletBalanceMonitoring } from './services/contractMonitor';
-import morgan from 'morgan';
+import {
+  contractMonitor,
+  setupDefaultEventListeners,
+  startWalletBalanceMonitoring,
+} from './services/contractMonitor';
 
 dotenv.config();
 
-const app = express();
+const app = createApp();
 const server = http.createServer(app);
 
-// Initialize Services
-connectDatabase();
 initWebSocket(server);
 initPriceMonitorCron();
-
-// Security middleware
-app.use(helmet());
-app.use(cors({
-  origin: config.corsOrigin || '*', // Fallback to * if config missing
-  credentials: true,
-}));
-
-// Metrics middleware (before other middleware to capture all requests)
-app.use(metricsMiddleware);
-
-// Rate limiting
-// app.use(rateLimiter);
-
-// Logging
-app.use(requestLogger);
-app.use(morgan('combined', { stream: { write: (msg: string) => logger.info(msg.trim()) } }));
-
-// Body parsing
-// Stripe webhooks require raw body for signature verification.
-app.use('/api/v1/bookings/webhook/stripe', express.raw({ type: 'application/json' }));
-app.use(express.json({ limit: '10mb' }));
-app.use(express.urlencoded({ extended: true }));
-
-// Health check
-app.get('/health', (_req, res) => {
-  res.json({
-    status: 'healthy',
-    timestamp: new Date().toISOString(),
-    version: process.env.npm_package_version || '0.1.0',
-    services: {
-      database: 'connected', // Optimistic
-      websocket: 'active',
-      cron: 'scheduled'
-    }
-  });
-});
-
-app.get('/readiness', async (_req, res) => {
-  try {
-    if (!AppDataSource.isInitialized && config.databaseUrl) {
-      return res.status(503).json({
-        status: 'unready',
-        reason: 'Database not initialized',
-      });
-    }
-    if (AppDataSource.isInitialized) {
-      await AppDataSource.query('SELECT 1');
-    }
-    return res.json({ status: 'ready' });
-  } catch (error: any) {
-    return res.status(503).json({
-      status: 'unready',
-      reason: error?.message || 'Database unavailable',
-    });
-  }
-});
-
-// API routes
-app.use('/metrics', metricsRoutes);
-app.use('/api/v1/flights', flightRoutes);
-app.use('/api/v1/subscriptions', subscriptionRoutes);
-app.use('/api/v1/governance', governanceRoutes);
-app.use('/api/v1/bookings', bookingRoutes);
-
-// Internal/dev-only utilities
-app.post('/internal/test-broadcast', (req, res) => {
-  if (config.environment === 'production') {
-    return res.status(403).json({ error: 'Forbidden' });
-  }
-
-  const { flightId = 'TEST-FLT', price = 100 } = req.body || {};
-  try {
-    const ws = getWebSocketServer();
-    ws.broadcastPriceUpdate(flightId, Number(price));
-    return res.json({ ok: true });
-  } catch (err) {
-    logger.warn('Failed to broadcast (ws not ready)', err);
-    return res.status(500).json({ ok: false, error: 'ws_not_ready' });
-  }
-});
-// app.use('/api/v1/airlines', airlineRoutes);
-// app.use('/api/v1/users', userRoutes);
-// app.use('/api/v1/refunds', refundRoutes);
-// app.use('/api/v1/loyalty', loyaltyRoutes);
-// app.use('/api/v1/wallet', walletRoutes);
-
-// Error handling
-app.use(errorHandler);
-
-// 404 handler
-app.use((_req, res) => {
-  res.status(404).json({
-    error: {
-      code: 'NOT_FOUND',
-      message: 'Endpoint not found',
-    },
-  });
-});
 
 const PORT = config.port || 3001;
 
@@ -144,29 +26,27 @@ if (process.env.NODE_ENV !== 'test') {
   initDataSource()
     .then(() => {
       server.listen(PORT, () => {
-        logger.info(`🚀 Traqora API server running on port ${PORT}`);
-        logger.info(`📡 Environment: ${config.environment}`);
-        logger.info(`🔗 Stellar Network: ${config.stellarNetwork}`);
-        logger.info(`🔄 WebSocket Server initialized`);
-        logger.info(`⏱️ Price Monitor Cron Job scheduled`);
-        
-        // Initialize contract monitoring
+        logger.info(`Traqora API server running on port ${PORT}`);
+        logger.info(`Environment: ${config.environment}`);
+        logger.info(`Stellar Network: ${config.stellarNetwork}`);
+
         setupDefaultEventListeners();
         contractMonitor.startMonitoring(5000);
-        logger.info(`📊 Contract event monitoring started`);
-        
-        // Start wallet balance monitoring
+
         const wallets = [
           { address: process.env.OPERATIONAL_WALLET_ADDRESS || '', type: 'operational' },
-        ].filter(w => w.address);
+        ].filter((wallet) => wallet.address);
+
         if (wallets.length > 0) {
           startWalletBalanceMonitoring(wallets);
-          logger.info(`💰 Wallet balance monitoring started for ${wallets.length} wallet(s)`);
         }
       });
     })
-    .catch((err) => {
-      logger.error({ error: 'Failed to initialize datasource', details: err?.message || err });
+    .catch((error) => {
+      logger.error({
+        error: 'Failed to initialize datasource',
+        details: error instanceof Error ? error.message : String(error),
+      });
       process.exit(1);
     });
 }

--- a/backend/src/middleware/authMiddleware.ts
+++ b/backend/src/middleware/authMiddleware.ts
@@ -8,24 +8,32 @@ export const requireAuth: RequestHandler = async (
     res: Response,
     next: NextFunction
 ): Promise<void> => {
+    const requestId = String(res.locals?.requestId || 'unknown');
+    const respondUnauthorized = (code: string) => {
+        res.status(401).json({
+            success: false,
+            error: {
+                code,
+                message: 'Unauthorized',
+                retryable: false,
+                requestId,
+                timestamp: new Date().toISOString(),
+            },
+        });
+    };
+
     try {
         const authHeader = req.headers.authorization;
 
         if (!authHeader || !authHeader.startsWith('Bearer ')) {
-            res.status(401).json({
-                error: 'Unauthorized',
-                code: 'TOKEN_MISSING',
-            });
+            respondUnauthorized('TOKEN_MISSING');
             return;
         }
 
         const token = authHeader.split(' ')[1];
 
         if (!token) {
-            res.status(401).json({
-                error: 'Unauthorized',
-                code: 'TOKEN_MISSING',
-            });
+            respondUnauthorized('TOKEN_MISSING');
             return;
         }
 
@@ -33,17 +41,11 @@ export const requireAuth: RequestHandler = async (
         jwt.verify(token, config.jwtSecret, (err, decoded) => {
             if (err) {
                 if (err.name === 'TokenExpiredError') {
-                    res.status(401).json({
-                        error: 'Unauthorized',
-                        code: 'TOKEN_EXPIRED',
-                    });
+                    respondUnauthorized('TOKEN_EXPIRED');
                     return;
                 }
 
-                res.status(401).json({
-                    error: 'Unauthorized',
-                    code: 'TOKEN_INVALID',
-                });
+                respondUnauthorized('TOKEN_INVALID');
                 return;
             }
 
@@ -58,7 +60,21 @@ export const requireAuth: RequestHandler = async (
             next();
         });
     } catch (error) {
-        logger.error('Auth middleware error:', error);
-        res.status(500).json({ error: 'Internal Server Error' });
+        logger.error('Auth middleware error', {
+            error: error instanceof Error ? error.message : String(error),
+            requestId,
+            operation: `${req.method} ${req.originalUrl || req.path}`,
+            userId: req.user?.walletAddress || 'anonymous',
+        });
+        res.status(500).json({
+            success: false,
+            error: {
+                code: 'INTERNAL_ERROR',
+                message: 'Internal Server Error',
+                retryable: false,
+                requestId,
+                timestamp: new Date().toISOString(),
+            },
+        });
     }
 };

--- a/backend/src/services/ErrorHandlingService.ts
+++ b/backend/src/services/ErrorHandlingService.ts
@@ -1,0 +1,313 @@
+import { logger } from '../utils/logger';
+
+export interface AppErrorOptions {
+  statusCode?: number;
+  code: string;
+  details?: unknown;
+  retryable?: boolean;
+  retryAfterMs?: number;
+  context?: Record<string, unknown>;
+}
+
+export class AppError extends Error {
+  public readonly statusCode: number;
+  public readonly code: string;
+  public readonly details?: unknown;
+  public readonly retryable: boolean;
+  public readonly retryAfterMs?: number;
+  public readonly context?: Record<string, unknown>;
+
+  constructor(message: string, options: AppErrorOptions) {
+    super(message);
+    this.name = 'AppError';
+    this.statusCode = options.statusCode ?? 500;
+    this.code = options.code;
+    this.details = options.details;
+    this.retryable = options.retryable ?? false;
+    this.retryAfterMs = options.retryAfterMs;
+    this.context = options.context;
+  }
+}
+
+export interface RetryOptions {
+  retries?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  jitter?: boolean;
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+  operationName?: string;
+}
+
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const getDelay = (
+  attempt: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+  jitter: boolean
+) => {
+  const backoffDelay = Math.min(baseDelayMs * Math.pow(2, attempt), maxDelayMs);
+  if (!jitter) return backoffDelay;
+
+  const jitterValue = Math.floor(Math.random() * Math.max(25, baseDelayMs));
+  return Math.min(backoffDelay + jitterValue, maxDelayMs);
+};
+
+export const isTransientError = (error: unknown): boolean => {
+  const anyError = error as Record<string, any>;
+  const message =
+    typeof anyError?.message === 'string'
+      ? anyError.message.toLowerCase()
+      : '';
+
+  if (
+    message.includes('timeout') ||
+    message.includes('timed out') ||
+    message.includes('socket hang up') ||
+    message.includes('econnreset') ||
+    message.includes('econnrefused') ||
+    message.includes('enotfound') ||
+    message.includes('temporarily unavailable') ||
+    message.includes('network')
+  ) {
+    return true;
+  }
+
+  const statusCode =
+    anyError?.statusCode ??
+    anyError?.status ??
+    anyError?.response?.status ??
+    anyError?.response?.statusCode;
+
+  return typeof statusCode === 'number' && statusCode >= 500;
+};
+
+export const withRetry = async <T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> => {
+  const retries = options.retries ?? 3;
+  const baseDelayMs = options.baseDelayMs ?? 250;
+  const maxDelayMs = options.maxDelayMs ?? 10_000;
+  const jitter = options.jitter ?? true;
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      const canRetry =
+        attempt < retries &&
+        (options.shouldRetry ? options.shouldRetry(error, attempt) : isTransientError(error));
+
+      if (!canRetry) {
+        break;
+      }
+
+      const delay = getDelay(attempt, baseDelayMs, maxDelayMs, jitter);
+      logger.warn('retrying_operation', {
+        operation: options.operationName ?? 'external_operation',
+        attempt: attempt + 1,
+        retries,
+        delayMs: delay,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      await sleep(delay);
+    }
+  }
+
+  throw lastError;
+};
+
+export interface CircuitBreakerOptions {
+  failureThreshold?: number;
+  recoveryTimeoutMs?: number;
+  halfOpenSuccesses?: number;
+}
+
+type CircuitState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+
+export class CircuitBreaker {
+  private state: CircuitState = 'CLOSED';
+  private failures = 0;
+  private openedAt: number | null = null;
+  private halfOpenSuccessCount = 0;
+
+  private readonly failureThreshold: number;
+  private readonly recoveryTimeoutMs: number;
+  private readonly halfOpenSuccesses: number;
+
+  constructor(
+    private readonly name: string,
+    options: CircuitBreakerOptions = {}
+  ) {
+    this.failureThreshold = options.failureThreshold ?? 5;
+    this.recoveryTimeoutMs = options.recoveryTimeoutMs ?? 30_000;
+    this.halfOpenSuccesses = options.halfOpenSuccesses ?? 1;
+  }
+
+  getState(): CircuitState {
+    if (
+      this.state === 'OPEN' &&
+      this.openedAt &&
+      Date.now() - this.openedAt >= this.recoveryTimeoutMs
+    ) {
+      this.state = 'HALF_OPEN';
+      this.halfOpenSuccessCount = 0;
+      logger.warn('circuit_half_open', { circuit: this.name });
+    }
+
+    return this.state;
+  }
+
+  async execute<T>(
+    operation: () => Promise<T>,
+    context: Record<string, unknown> = {}
+  ): Promise<T> {
+    const state = this.getState();
+    if (state === 'OPEN') {
+      const retryAfterMs = Math.max(
+        0,
+        this.recoveryTimeoutMs - (Date.now() - (this.openedAt ?? Date.now()))
+      );
+      throw new AppError('External service is temporarily unavailable', {
+        statusCode: 503,
+        code: 'CIRCUIT_OPEN',
+        retryable: true,
+        retryAfterMs,
+        context: { circuit: this.name, ...context },
+      });
+    }
+
+    try {
+      const result = await operation();
+      this.onSuccess();
+      return result;
+    } catch (error) {
+      this.onFailure(error, context);
+      throw error;
+    }
+  }
+
+  private onSuccess() {
+    if (this.state === 'HALF_OPEN') {
+      this.halfOpenSuccessCount += 1;
+      if (this.halfOpenSuccessCount >= this.halfOpenSuccesses) {
+        this.reset();
+      }
+      return;
+    }
+
+    this.failures = 0;
+  }
+
+  private onFailure(error: unknown, context: Record<string, unknown>) {
+    this.failures += 1;
+
+    if (this.state === 'HALF_OPEN' || this.failures >= this.failureThreshold) {
+      this.state = 'OPEN';
+      this.openedAt = Date.now();
+      this.halfOpenSuccessCount = 0;
+      logger.error('circuit_opened', {
+        circuit: this.name,
+        failures: this.failures,
+        error: error instanceof Error ? error.message : String(error),
+        ...context,
+      });
+      return;
+    }
+
+    this.state = 'CLOSED';
+  }
+
+  private reset() {
+    this.state = 'CLOSED';
+    this.failures = 0;
+    this.openedAt = null;
+    this.halfOpenSuccessCount = 0;
+    logger.info('circuit_closed', { circuit: this.name });
+  }
+}
+
+export interface ExternalExecutionOptions {
+  operationName: string;
+  context?: Record<string, unknown>;
+  retry?: RetryOptions;
+}
+
+export interface WorkflowStep {
+  name: string;
+  run: () => Promise<void>;
+  compensate?: () => Promise<void>;
+}
+
+export const executeWithResilience = async <T>(
+  breaker: CircuitBreaker,
+  fn: () => Promise<T>,
+  options: ExternalExecutionOptions
+): Promise<T> => {
+  const operationContext = options.context ?? {};
+
+  try {
+    return await breaker.execute(
+      () =>
+        withRetry(fn, {
+          operationName: options.operationName,
+          ...options.retry,
+        }),
+      operationContext
+    );
+  } catch (error) {
+    logger.error('external_operation_failed', {
+      operation: options.operationName,
+      error: error instanceof Error ? error.message : String(error),
+      ...operationContext,
+    });
+    throw error;
+  }
+};
+
+export const executeCompensatedWorkflow = async (
+  operationName: string,
+  steps: WorkflowStep[]
+): Promise<void> => {
+  const completed: WorkflowStep[] = [];
+
+  try {
+    for (const step of steps) {
+      await step.run();
+      completed.push(step);
+    }
+  } catch (error) {
+    const failedStep = steps[completed.length]?.name ?? 'unknown_step';
+
+    for (const step of completed.reverse()) {
+      if (!step.compensate) continue;
+      try {
+        await step.compensate();
+      } catch (compensationError) {
+        logger.error('workflow_compensation_failed', {
+          operation: operationName,
+          step: step.name,
+          error:
+            compensationError instanceof Error
+              ? compensationError.message
+              : String(compensationError),
+        });
+      }
+    }
+
+    throw new AppError('Operation partially failed and rollback was triggered', {
+      statusCode: 503,
+      code: 'PARTIAL_FAILURE_RECOVERED',
+      retryable: true,
+      details: {
+        operation: operationName,
+        failedStep,
+      },
+    });
+  }
+};

--- a/backend/src/services/contractMonitor.ts
+++ b/backend/src/services/contractMonitor.ts
@@ -2,6 +2,7 @@ import * as StellarSdk from '@stellar/stellar-sdk';
 import { config } from '../config';
 import { logger } from '../utils/logger';
 import { recordContractEvent, updateWalletBalance, recordSorobanTransaction } from './metrics';
+import { executeSorobanOperation } from './soroban';
 
 interface ContractEventListener {
   contractId: string;
@@ -76,21 +77,30 @@ class ContractMonitor {
 
     try {
       // Get latest ledger
-      const latestLedger = await this.server.getLatestLedger();
+      const latestLedger = await executeSorobanOperation(
+        'soroban_get_latest_ledger',
+        () => this.server!.getLatestLedger(),
+        { component: 'contract_monitor' }
+      );
       
       // Fetch events for each registered contract
       for (const listener of this.listeners) {
         try {
-          const events = await this.server.getEvents({
-            startLedger: this.lastCursor ? undefined : latestLedger.sequence - 100,
-            filters: [
-              {
-                type: 'contract',
-                contractIds: [listener.contractId],
-              },
-            ],
-            limit: 100,
-          });
+          const events = await executeSorobanOperation(
+            'soroban_get_events',
+            () =>
+              this.server!.getEvents({
+                startLedger: this.lastCursor ? undefined : latestLedger.sequence - 100,
+                filters: [
+                  {
+                    type: 'contract',
+                    contractIds: [listener.contractId],
+                  },
+                ],
+                limit: 100,
+              }),
+            { contractId: listener.contractId, component: 'contract_monitor' }
+          );
 
           if (events.events && events.events.length > 0) {
             for (const event of events.events) {
@@ -178,7 +188,11 @@ class ContractMonitor {
 
     for (const wallet of wallets) {
       try {
-        const account = await horizonServer.loadAccount(wallet.address);
+          const account = await executeSorobanOperation(
+            'horizon_load_account',
+            () => horizonServer.loadAccount(wallet.address),
+            { wallet: wallet.address, component: 'contract_monitor' }
+          );
         
         // Find XLM balance
         const xlmBalance = account.balances.find(
@@ -221,7 +235,11 @@ class ContractMonitor {
     if (!this.server) return;
 
     try {
-      const response = await this.server.getTransaction(txHash);
+      const response = await executeSorobanOperation(
+        'soroban_get_transaction',
+        () => this.server!.getTransaction(txHash),
+        { txHash, contract, method, component: 'contract_monitor' }
+      );
       const duration = (Date.now() - startTime) / 1000;
 
       if (response.status === StellarSdk.SorobanRpc.Api.GetTransactionStatus.SUCCESS) {

--- a/backend/src/services/flightRegistryService.ts
+++ b/backend/src/services/flightRegistryService.ts
@@ -2,6 +2,7 @@ import * as StellarSdk from '@stellar/stellar-sdk';
 import { config } from '../config';
 import { Flight } from '../types/flight';
 import { logger } from '../utils/logger';
+import { executeSorobanOperation } from './soroban';
 
 export interface FlightRegistryState {
   listed: boolean;
@@ -39,7 +40,11 @@ class SorobanFlightRegistryService implements FlightRegistryService {
     try {
       const server = new StellarSdk.SorobanRpc.Server(config.sorobanRpcUrl);
       const registryContract = new StellarSdk.Contract(config.contracts.flightRegistry);
-      const source = await server.getAccount(StellarSdk.Keypair.random().publicKey());
+      const source = await executeSorobanOperation(
+        'soroban_get_account',
+        () => server.getAccount(StellarSdk.Keypair.random().publicKey()),
+        { component: 'flight_registry' }
+      );
       const networkPassphrase =
         config.stellarNetwork === 'mainnet'
           ? StellarSdk.Networks.PUBLIC
@@ -61,7 +66,11 @@ class SorobanFlightRegistryService implements FlightRegistryService {
           .setTimeout(30)
           .build();
 
-        const simulated = await server.simulateTransaction(tx);
+        const simulated = await executeSorobanOperation(
+          'soroban_simulate_flight_state',
+          () => server.simulateTransaction(tx),
+          { component: 'flight_registry', flightId: flight.id }
+        );
         if (!StellarSdk.SorobanRpc.Api.isSimulationSuccess(simulated) || !simulated.result?.retval) {
           states[flight.id] = {
             listed: false,

--- a/backend/src/services/loyalty/contractSync.ts
+++ b/backend/src/services/loyalty/contractSync.ts
@@ -1,6 +1,7 @@
 import { config } from '../../config';
 import { LoyaltyStore } from './store';
 import { logger } from '../../utils/logger';
+import { executeSorobanOperation } from '../soroban';
 
 export interface OnChainAccount {
   address: string;
@@ -63,7 +64,11 @@ export class ContractSync {
       const address = new Address(stellarAddress);
 
       const call = contract.call('get_account', address.toScVal());
-      const simResponse = await server.simulateTransaction(call as never);
+      const simResponse = await executeSorobanOperation(
+        'soroban_simulate_loyalty_get_account',
+        () => server.simulateTransaction(call as never),
+        { component: 'loyalty_contract_sync', stellarAddress }
+      );
 
       if ('error' in simResponse) {
         logger.warn({ msg: 'Contract simulation failed', error: simResponse.error });

--- a/backend/src/services/refundService.ts
+++ b/backend/src/services/refundService.ts
@@ -1,7 +1,7 @@
 import { AppDataSource } from '../db/dataSource';
 import { Refund, RefundReason, RefundStatus } from '../db/entities/Refund';
 import { Booking } from '../db/entities/Booking';
-import { stripe } from './stripe';
+import { executeStripeOperation, stripe } from './stripe';
 import { buildBatchBookingActionUnsignedXdr, submitSignedSorobanXdr, getTransactionStatus } from './soroban';
 import { NotificationService } from './NotificationService';
 import { RefundAuditService } from './refundAuditService';
@@ -189,9 +189,10 @@ export class RefundService {
     try {
       // Step 1: Process Stripe refund
       if (refund.booking.stripePaymentIntentId && refund.approvedAmountCents! > 0) {
-        const stripeRefund = await withRetries(
-          async () => {
-            return await stripe.refunds.create({
+        const stripeRefund = await executeStripeOperation(
+          'stripe_create_refund',
+          () =>
+            stripe.refunds.create({
               payment_intent: refund.booking.stripePaymentIntentId!,
               amount: refund.approvedAmountCents!,
               reason: 'requested_by_customer',
@@ -199,9 +200,11 @@ export class RefundService {
                 refundId: refund.id,
                 bookingId: refund.booking.id,
               },
-            });
-          },
-          { retries: 3, baseDelayMs: 500 }
+            }),
+          {
+            refundId: refund.id,
+            bookingId: refund.booking.id,
+          }
         );
 
         refund.stripeRefundId = stripeRefund.id;

--- a/backend/src/services/retry.ts
+++ b/backend/src/services/retry.ts
@@ -1,19 +1,33 @@
-export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+import { RetryOptions, sleep, withRetry } from './ErrorHandlingService';
 
-export const withRetries = async <T>(fn: () => Promise<T>, opts?: { retries?: number; baseDelayMs?: number }) => {
-  const retries = opts?.retries ?? 3;
-  const baseDelayMs = opts?.baseDelayMs ?? 250;
+export { sleep };
 
-  let lastErr: unknown;
-  for (let attempt = 0; attempt <= retries; attempt++) {
-    try {
-      return await fn();
-    } catch (err) {
-      lastErr = err;
-      if (attempt === retries) break;
-      const delay = baseDelayMs * Math.pow(2, attempt);
-      await sleep(delay);
-    }
-  }
-  throw lastErr;
+export type LegacyRetryOptions = {
+  retries?: number;
+  baseDelayMs?: number;
+  maxAttempts?: number;
+  delayMs?: number;
+  backoff?: boolean;
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+  operationName?: string;
 };
+
+const mapLegacyOptions = (opts?: LegacyRetryOptions): RetryOptions => {
+  const retries =
+    opts?.maxAttempts !== undefined
+      ? Math.max(0, opts.maxAttempts - 1)
+      : opts?.retries;
+
+  return {
+    retries,
+    baseDelayMs: opts?.delayMs ?? opts?.baseDelayMs,
+    jitter: opts?.backoff ?? true,
+    shouldRetry: opts?.shouldRetry,
+    operationName: opts?.operationName,
+  };
+};
+
+export const withRetries = async <T>(
+  fn: () => Promise<T>,
+  opts?: LegacyRetryOptions
+): Promise<T> => withRetry(fn, mapLegacyOptions(opts));

--- a/backend/src/services/soroban.ts
+++ b/backend/src/services/soroban.ts
@@ -2,6 +2,12 @@ import { config } from '../config';
 import * as StellarSdk from '@stellar/stellar-sdk';
 import { logger } from '../utils/logger';
 import crypto from 'crypto';
+import {
+  AppError,
+  CircuitBreaker,
+  executeWithResilience,
+  isTransientError,
+} from './ErrorHandlingService';
 
 export type UnsignedSorobanTx = {
   xdr: string;
@@ -27,7 +33,11 @@ export const buildBatchBookingActionUnsignedXdr = async (params: {
 
     const server = getSorobanServer();
     const networkPassphrase = getNetworkPassphrase();
-    const sourceAccount = await server.getAccount(params.actor);
+    const sourceAccount = await executeSorobanOperation(
+      'soroban_get_account',
+      () => server.getAccount(params.actor),
+      { actor: params.actor, action: params.action }
+    );
     const contract = new StellarSdk.Contract(config.contracts.booking);
 
     const actorVal = new StellarSdk.Address(params.actor).toScVal();
@@ -43,7 +53,11 @@ export const buildBatchBookingActionUnsignedXdr = async (params: {
       .setTimeout(300)
       .build();
 
-    const simulated = await server.simulateTransaction(transaction);
+    const simulated = await executeSorobanOperation(
+      'soroban_simulate_batch_action',
+      () => server.simulateTransaction(transaction),
+      { actor: params.actor, action: params.action }
+    );
     if (StellarSdk.SorobanRpc.Api.isSimulationSuccess(simulated)) {
       const prepared = StellarSdk.SorobanRpc.assembleTransaction(
         transaction,
@@ -74,6 +88,10 @@ export type TransactionStatus = {
 };
 
 let server: StellarSdk.SorobanRpc.Server | null = null;
+const sorobanCircuitBreaker = new CircuitBreaker('soroban-rpc', {
+  failureThreshold: 5,
+  recoveryTimeoutMs: 30_000,
+});
 
 const getSorobanServer = (): StellarSdk.SorobanRpc.Server => {
   if (!server) {
@@ -81,6 +99,21 @@ const getSorobanServer = (): StellarSdk.SorobanRpc.Server => {
   }
   return server;
 };
+
+export const executeSorobanOperation = async <T>(
+  operationName: string,
+  fn: () => Promise<T>,
+  context: Record<string, unknown> = {}
+): Promise<T> =>
+  executeWithResilience(sorobanCircuitBreaker, fn, {
+    operationName,
+    context,
+    retry: {
+      retries: 3,
+      baseDelayMs: 300,
+      shouldRetry: (error) => isTransientError(error),
+    },
+  });
 
 const getNetworkPassphrase = (): string => {
   return config.stellarNetwork === 'mainnet'
@@ -110,7 +143,11 @@ export const buildCreateBookingUnsignedXdr = async (params: {
     const networkPassphrase = getNetworkPassphrase();
 
     // Get source account (fee estimation)
-    const sourceAccount = await server.getAccount(params.passenger);
+    const sourceAccount = await executeSorobanOperation(
+      'soroban_get_account',
+      () => server.getAccount(params.passenger),
+      { passenger: params.passenger, action: 'create_booking' }
+    );
 
     // Build contract invocation
     const contract = new StellarSdk.Contract(config.contracts.booking);
@@ -139,7 +176,11 @@ export const buildCreateBookingUnsignedXdr = async (params: {
       .build();
 
     // Simulate to get accurate fee
-    const simulated = await server.simulateTransaction(transaction);
+    const simulated = await executeSorobanOperation(
+      'soroban_simulate_create_booking',
+      () => server.simulateTransaction(transaction),
+      { passenger: params.passenger, action: 'create_booking' }
+    );
     
     if (StellarSdk.SorobanRpc.Api.isSimulationSuccess(simulated)) {
       // Prepare the transaction with simulated results
@@ -185,7 +226,11 @@ export const signAndSubmitCreateBooking = async (params: {
     const server = getSorobanServer();
     const networkPassphrase = getNetworkPassphrase();
     const sourceKeypair = StellarSdk.Keypair.fromSecret(config.stellarSecretKey);
-    const sourceAccount = await server.getAccount(sourceKeypair.publicKey());
+    const sourceAccount = await executeSorobanOperation(
+      'soroban_get_account',
+      () => server.getAccount(sourceKeypair.publicKey()),
+      { action: 'sign_and_submit_create_booking' }
+    );
 
     // Build contract invocation
     const contract = new StellarSdk.Contract(config.contracts.booking);
@@ -214,7 +259,11 @@ export const signAndSubmitCreateBooking = async (params: {
       .build();
 
     // Simulate and prepare
-    const simulated = await server.simulateTransaction(transaction);
+    const simulated = await executeSorobanOperation(
+      'soroban_simulate_signed_create_booking',
+      () => server.simulateTransaction(transaction),
+      { action: 'sign_and_submit_create_booking' }
+    );
     if (!StellarSdk.SorobanRpc.Api.isSimulationSuccess(simulated)) {
       throw new Error(`Simulation failed: ${simulated.error || 'Unknown error'}`);
     }
@@ -223,7 +272,11 @@ export const signAndSubmitCreateBooking = async (params: {
     prepared.sign(sourceKeypair);
 
     // Submit
-    const response = await server.sendTransaction(prepared);
+    const response = await executeSorobanOperation(
+      'soroban_send_signed_create_booking',
+      () => server.sendTransaction(prepared),
+      { action: 'sign_and_submit_create_booking' }
+    );
     if (response.status === 'ERROR') {
       throw new Error(`Submission failed: ${response.status}`);
     }
@@ -254,7 +307,11 @@ export const submitSignedSorobanXdr = async (signedXdr: string): Promise<{ txHas
     ) as StellarSdk.Transaction;
 
     // Submit transaction
-    const response = await server.sendTransaction(transaction);
+    const response = await executeSorobanOperation(
+      'soroban_submit_signed_xdr',
+      () => server.sendTransaction(transaction),
+      { action: 'submit_signed_xdr' }
+    );
 
     // response.status type may not include SUCCESS/PENDING in typings
     const status: any = response.status;
@@ -287,7 +344,11 @@ export const getTransactionStatus = async (txHash: string): Promise<TransactionS
     }
 
     const server = getSorobanServer();
-    const response = await server.getTransaction(txHash);
+    const response = await executeSorobanOperation(
+      'soroban_get_transaction',
+      () => server.getTransaction(txHash),
+      { txHash }
+    );
 
     if (response.status === StellarSdk.SorobanRpc.Api.GetTransactionStatus.SUCCESS) {
       return {
@@ -314,6 +375,14 @@ export const getTransactionStatus = async (txHash: string): Promise<TransactionS
     }
   } catch (error: any) {
     logger.error('Error getting transaction status', { error: error.message, txHash });
+    if (error instanceof AppError && error.code === 'CIRCUIT_OPEN') {
+      return {
+        status: 'pending',
+        txHash,
+        error: 'Soroban RPC temporarily unavailable',
+      };
+    }
+
     return {
       status: 'not_found',
       txHash,

--- a/backend/src/services/stripe.ts
+++ b/backend/src/services/stripe.ts
@@ -1,4 +1,9 @@
 import Stripe from 'stripe';
+import {
+  CircuitBreaker,
+  executeWithResilience,
+  isTransientError,
+} from './ErrorHandlingService';
 
 const apiKey = process.env.STRIPE_SECRET_KEY || '';
 
@@ -7,3 +12,23 @@ export const stripe = new Stripe(apiKey, {
 });
 
 export const stripeWebhookSecret = process.env.STRIPE_WEBHOOK_SECRET || '';
+
+const stripeCircuitBreaker = new CircuitBreaker('stripe-api', {
+  failureThreshold: 5,
+  recoveryTimeoutMs: 30_000,
+});
+
+export const executeStripeOperation = async <T>(
+  operationName: string,
+  fn: () => Promise<T>,
+  context: Record<string, unknown> = {}
+): Promise<T> =>
+  executeWithResilience(stripeCircuitBreaker, fn, {
+    operationName,
+    context,
+    retry: {
+      retries: 3,
+      baseDelayMs: 300,
+      shouldRetry: (error) => isTransientError(error),
+    },
+  });

--- a/backend/src/utils/errorHandler.ts
+++ b/backend/src/utils/errorHandler.ts
@@ -1,11 +1,14 @@
 import { NextFunction, Request, Response } from 'express';
 import { logger } from './logger';
 import { mapStellarError } from './stellarErrors';
+import { AppError } from '../services/ErrorHandlingService';
 
 export interface ApiError extends Error {
   statusCode?: number;
   code?: string;
   details?: unknown;
+  retryable?: boolean;
+  retryAfterMs?: number;
 }
 
 export const errorHandler = (
@@ -14,29 +17,59 @@ export const errorHandler = (
   res: Response,
   _next: NextFunction
 ) => {
-  const statusCode = err.statusCode || 500;
+  const appError =
+    err instanceof AppError
+      ? err
+      : new AppError(err.message || 'Internal Server Error', {
+          statusCode: err.statusCode || 500,
+          code: err.code || 'INTERNAL_ERROR',
+          details: err.details,
+          retryable: err.retryable,
+          retryAfterMs: err.retryAfterMs,
+        });
+
+  const statusCode = appError.statusCode;
   const stellarMapping = mapStellarError(err);
   const message =
-    stellarMapping?.message || err.message || 'Internal Server Error';
-  const code = stellarMapping?.code || err.code || 'INTERNAL_ERROR';
+    stellarMapping?.message || appError.message || 'Internal Server Error';
+  const code = stellarMapping?.code || appError.code || 'INTERNAL_ERROR';
   const details =
     stellarMapping?.details ||
-    err.details ||
+    appError.details ||
     (process.env.NODE_ENV === 'development' ? { stack: err.stack } : undefined);
+  const retryable = appError.retryable || false;
+  const retryAfterMs = appError.retryAfterMs;
+  const requestId = String(res.locals.requestId || 'unknown');
+  const userId = req.user?.walletAddress || 'anonymous';
+  const operation = `${req.method} ${req.originalUrl || req.path}`;
 
   logger.error({
-    error: err.message,
+    error: appError.message,
     stack: err.stack,
-    code: err.code,
+    code: appError.code,
     path: req.path,
     method: req.method,
     ip: req.ip,
+    userId,
+    operation,
+    requestId,
+    retryable,
+    retryAfterMs,
   });
 
+  if (retryAfterMs && retryAfterMs > 0) {
+    res.setHeader('Retry-After', Math.ceil(retryAfterMs / 1000).toString());
+  }
+
   res.status(statusCode).json({
+    success: false,
     error: {
       code,
       message,
+      retryable,
+      requestId,
+      timestamp: new Date().toISOString(),
+      ...(retryAfterMs ? { retryAfterMs } : {}),
       ...(details ? { details } : {}),
     },
   });

--- a/backend/tests/auth/authMiddleware.integration.test.ts
+++ b/backend/tests/auth/authMiddleware.integration.test.ts
@@ -15,6 +15,7 @@ describe('authMiddleware', () => {
         mockResponse = {
             status: jest.fn().mockReturnThis(),
             json: jest.fn(),
+            locals: {},
         };
         mockNext = jest.fn();
     });
@@ -22,10 +23,15 @@ describe('authMiddleware', () => {
     it('should return 401 if Authorization header is missing', async () => {
         await requireAuth(mockRequest as Request, mockResponse as Response, mockNext);
         expect(mockResponse.status).toHaveBeenCalledWith(401);
-        expect(mockResponse.json).toHaveBeenCalledWith({
-            error: 'Unauthorized',
-            code: 'TOKEN_MISSING'
-        });
+        expect(mockResponse.json).toHaveBeenCalledWith(
+            expect.objectContaining({
+                success: false,
+                error: expect.objectContaining({
+                    code: 'TOKEN_MISSING',
+                    message: 'Unauthorized',
+                }),
+            })
+        );
     });
 
     it('should populate req.user if token is valid', async () => {
@@ -48,9 +54,14 @@ describe('authMiddleware', () => {
         await requireAuth(mockRequest as Request, mockResponse as Response, mockNext);
 
         expect(mockResponse.status).toHaveBeenCalledWith(401);
-        expect(mockResponse.json).toHaveBeenCalledWith({
-            error: 'Unauthorized',
-            code: 'TOKEN_EXPIRED'
-        });
+        expect(mockResponse.json).toHaveBeenCalledWith(
+            expect.objectContaining({
+                success: false,
+                error: expect.objectContaining({
+                    code: 'TOKEN_EXPIRED',
+                    message: 'Unauthorized',
+                }),
+            })
+        );
     });
 });

--- a/backend/tests/bookings.integration.test.ts
+++ b/backend/tests/bookings.integration.test.ts
@@ -48,7 +48,9 @@ describe('Booking flow', () => {
       .set('Idempotency-Key', 'idem-auth-fail')
       .send({})
       .expect(401);
-    expect(res.body.error).toBe('Unauthorized');
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('TOKEN_MISSING');
+    expect(res.body.error.message).toBe('Unauthorized');
   });
 
   beforeAll(async () => {

--- a/backend/tests/integration/error-handling.integration.test.ts
+++ b/backend/tests/integration/error-handling.integration.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+import { errorHandler } from '../../src/utils/errorHandler';
+import {
+  AppError,
+  CircuitBreaker,
+  executeCompensatedWorkflow,
+  executeWithResilience,
+} from '../../src/services/ErrorHandlingService';
+import { withRetries } from '../../src/services/retry';
+import { requestLogger } from '../../src/middleware/requestLogger';
+
+describe('error handling resilience', () => {
+  it('returns standardized error payload with retry hints', async () => {
+    const app = express();
+    app.use(requestLogger);
+
+    app.get('/boom', (_req, _res, next) => {
+      next(
+        new AppError('Upstream unavailable', {
+          statusCode: 503,
+          code: 'UPSTREAM_UNAVAILABLE',
+          retryable: true,
+          retryAfterMs: 12000,
+          details: { dependency: 'soroban' },
+        })
+      );
+    });
+
+    app.use(errorHandler);
+
+    const response = await request(app).get('/boom');
+    expect(response.status).toBe(503);
+    expect(response.body.success).toBe(false);
+    expect(response.body.error.code).toBe('UPSTREAM_UNAVAILABLE');
+    expect(response.body.error.retryable).toBe(true);
+    expect(response.body.error.retryAfterMs).toBe(12000);
+    expect(response.body.error.requestId).toBeTruthy();
+    expect(response.body.error.timestamp).toBeTruthy();
+    expect(response.headers['retry-after']).toBe('12');
+  });
+
+  it('retries transient timeout failures and then succeeds', async () => {
+    let attempts = 0;
+
+    const result = await withRetries(
+      async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          throw new Error('network timeout while calling soroban rpc');
+        }
+        return 'ok';
+      },
+      {
+        retries: 4,
+        baseDelayMs: 1,
+        backoff: false,
+      }
+    );
+
+    expect(result).toBe('ok');
+    expect(attempts).toBe(3);
+  });
+
+  it('retries transient 500 errors and succeeds', async () => {
+    let attempts = 0;
+
+    const result = await withRetries(
+      async () => {
+        attempts += 1;
+        if (attempts < 3) {
+          const error = new Error('service unavailable') as Error & {
+            response?: { status: number };
+          };
+          error.response = { status: 500 };
+          throw error;
+        }
+        return { ok: true };
+      },
+      { retries: 3, baseDelayMs: 1, backoff: false }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(attempts).toBe(3);
+  });
+
+  it('opens circuit after 5 consecutive failures and short-circuits subsequent requests', async () => {
+    const breaker = new CircuitBreaker('test-upstream', {
+      failureThreshold: 5,
+      recoveryTimeoutMs: 60_000,
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      await expect(
+        executeWithResilience(
+          breaker,
+          async () => {
+            throw new Error('upstream timeout');
+          },
+          {
+            operationName: 'test_upstream_call',
+            retry: { retries: 0 },
+          }
+        )
+      ).rejects.toThrow();
+    }
+
+    await expect(
+      executeWithResilience(
+        breaker,
+        async () => 'ok',
+        {
+          operationName: 'test_upstream_call',
+          retry: { retries: 0 },
+        }
+      )
+    ).rejects.toMatchObject({ code: 'CIRCUIT_OPEN', statusCode: 503 });
+  });
+
+  it('runs compensation steps after partial workflow failure', async () => {
+    const sideEffects: string[] = [];
+
+    await expect(
+      executeCompensatedWorkflow('booking_payment_confirmation', [
+        {
+          name: 'reserve_seat',
+          run: async () => {
+            sideEffects.push('seat_reserved');
+          },
+          compensate: async () => {
+            sideEffects.push('seat_released');
+          },
+        },
+        {
+          name: 'capture_payment',
+          run: async () => {
+            sideEffects.push('payment_captured');
+          },
+          compensate: async () => {
+            sideEffects.push('payment_refunded');
+          },
+        },
+        {
+          name: 'confirm_onchain',
+          run: async () => {
+            throw new Error('soroban timeout');
+          },
+        },
+      ])
+    ).rejects.toMatchObject({
+      code: 'PARTIAL_FAILURE_RECOVERED',
+      statusCode: 503,
+      retryable: true,
+    });
+
+    expect(sideEffects).toEqual([
+      'seat_reserved',
+      'payment_captured',
+      'payment_refunded',
+      'seat_released',
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #93

## Summary
- add a centralized backend resilience layer with standardized AppError, retry/backoff, and circuit breaker patterns
- enforce a consistent API error response contract with retry hints, requestId, and timestamp
- integrate resilient wrappers for Soroban and Stripe interaction paths to handle transient failures safely
- add a compensation-safe workflow helper for partial multi-step failures
- document operator recovery procedures in backend/docs/error-recovery-guide.md

## Security and reliability
- fail-safe external dependency handling via circuit open after 5 failures
- retry only transient failures with bounded exponential backoff
- structured error logs now include context (requestId, operation, userId where available)
- no unsafe manual data mutation steps introduced

## Testing
- added integration tests for:
  - standardized error format and retry hints
  - timeout and 500 transient retry behavior
  - circuit breaker open-state behavior
  - partial-failure compensation workflow
- updated auth middleware tests for standardized error envelope
- commands run locally:
  - npx jest --config jest.config.cjs --runInBand tests/integration/error-handling.integration.test.ts tests/auth/authMiddleware.integration.test.ts

## Notes
- repo still has a pre-existing TypeScript project config/build issue (TS6305) unrelated to this feature work
