### PR TITLE
feat: harden client Dockerfile + add Trivy and axe a11y CI

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,56 @@
+# Issue #168 — accessibility audits on the client app's core pages.
+#
+# Boots the Next.js dev server, drives Playwright + axe-core against the
+# pages the issue lists (/, /search, /book), and fails the workflow on
+# any HIGH or CRITICAL impact violation. A `serious` finding becomes a
+# warning in the job summary but does not block — gives the team a place
+# to ratchet thresholds tighter as the surface gets cleaner.
+
+name: Accessibility (axe)
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - 'packages/client/**'
+      - '.github/workflows/a11y.yml'
+  pull_request:
+    paths:
+      - 'packages/client/**'
+      - '.github/workflows/a11y.yml'
+
+jobs:
+  axe:
+    name: Playwright + axe-core
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: packages/client
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: packages/client/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps --ignore-scripts
+
+      - name: Install Playwright + axe-core test deps
+        run: npm install --no-save --legacy-peer-deps @playwright/test @axe-core/playwright
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run axe a11y suite
+        env:
+          # Disable telemetry / analytics during the audit so axe doesn't
+          # flag third-party iframes the team can't fix.
+          NEXT_TELEMETRY_DISABLED: '1'
+        run: npx playwright test tests/a11y --reporter=list

--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -1,0 +1,81 @@
+# Issue #162 — Docker image security scan with Trivy.
+#
+# Builds both production images (backend + client) for the current PR /
+# push and runs aquasecurity/trivy on them at HIGH+CRITICAL severity. A
+# CRITICAL/HIGH finding fails the workflow. The job runs in a matrix so
+# results for each image are surfaced independently.
+
+name: Docker Security Scan
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - 'packages/backend/Dockerfile'
+      - 'packages/client/Dockerfile'
+      - 'docker-compose*.yml'
+      - '.github/workflows/docker-security.yml'
+  pull_request:
+    paths:
+      - 'packages/backend/Dockerfile'
+      - 'packages/client/Dockerfile'
+      - 'docker-compose*.yml'
+      - '.github/workflows/docker-security.yml'
+
+jobs:
+  scan:
+    name: Scan ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: backend
+            context: packages/backend
+          - image: client
+            context: packages/client
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build production image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          target: production
+          push: false
+          load: true
+          tags: traqora-${{ matrix.image }}:scan
+
+      - name: Scan with Trivy (HIGH, CRITICAL)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: traqora-${{ matrix.image }}:scan
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: os,library
+          format: table
+
+      - name: Upload Trivy SARIF (advisory)
+        if: always()
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: traqora-${{ matrix.image }}:scan
+          severity: HIGH,CRITICAL
+          format: sarif
+          output: trivy-${{ matrix.image }}.sarif
+          exit-code: '0'
+          ignore-unfixed: true
+
+      - name: Upload SARIF as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-${{ matrix.image }}-sarif
+          path: trivy-${{ matrix.image }}.sarif
+          retention-days: 14

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -1,45 +1,76 @@
-# Development stage
+# syntax=docker/dockerfile:1.7
+#
+# packages/client — hardened multi-stage Next.js production image.
+#
+# Issue #162. Adds: non-root runtime user, HEALTHCHECK, --ignore-scripts
+# during install (no untrusted lifecycle scripts on `npm install`),
+# `npm ci` in the build stage for reproducible installs, and a final
+# runner stage that drops every dev dependency from disk.
+
+# ─── Development stage (used by docker-compose.yml hot-reload) ──────────────
 FROM node:20-alpine AS development
 
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-RUN npm install --legacy-peer-deps
+RUN npm install --legacy-peer-deps --ignore-scripts
 
 COPY . .
 
-# Next.js dev server port
 EXPOSE 3000
-
-# Set environment to development
 ENV NODE_ENV=development
 
-# Run next dev for hot-reloading
 CMD ["npm", "run", "dev"]
 
-# Production stage
-FROM node:20-alpine AS production
+
+# ─── Build stage — install + next build ────────────────────────────────────
+FROM node:20-alpine AS build
 
 WORKDIR /usr/src/app
 
+# Reproducible install from package-lock.json. --legacy-peer-deps matches
+# the dev install for parity. --ignore-scripts blocks any untrusted
+# lifecycle scripts during install; the Next.js build below runs the
+# scripts we control.
 COPY package*.json ./
-RUN npm install --legacy-peer-deps
+RUN npm ci --legacy-peer-deps --ignore-scripts
 
 COPY . .
 RUN npm run build
 
-# Only copy necessary files for production
-FROM node:20-alpine AS runner
+
+# ─── Runner stage — minimal, non-root, healthchecked ───────────────────────
+FROM node:20-alpine AS production
+
+# Non-root runtime user (issue #162). Node 20-alpine ships with a `node`
+# user but it isn't reliably guaranteed across base-image rebuilds, so we
+# create a dedicated group/user with a fixed UID for reproducibility.
+RUN addgroup -g 1001 -S nextjs \
+    && adduser -S -G nextjs -u 1001 nextjs
+
 WORKDIR /usr/src/app
 
-ENV NODE_ENV=production
+# Production dependencies only — no dev dependencies on the runtime image.
+COPY package*.json ./
+RUN npm ci --omit=dev --legacy-peer-deps --ignore-scripts \
+    && npm cache clean --force
 
-COPY --from=production /usr/src/app/next.config.mjs ./
-COPY --from=production /usr/src/app/public ./public
-COPY --from=production /usr/src/app/.next ./.next
-COPY --from=production /usr/src/app/node_modules ./node_modules
-COPY --from=production /usr/src/app/package.json ./package.json
+# Built artefacts and the runtime config Next.js needs.
+COPY --from=build --chown=nextjs:nextjs /usr/src/app/next.config.mjs ./next.config.mjs
+COPY --from=build --chown=nextjs:nextjs /usr/src/app/public ./public
+COPY --from=build --chown=nextjs:nextjs /usr/src/app/.next ./.next
+
+USER nextjs
+
+ENV NODE_ENV=production
+ENV PORT=3000
 
 EXPOSE 3000
+
+# Liveness probe used by Docker / Kubernetes. `wget --spider` exits 0 on
+# 2xx/3xx, so this only marks the container unhealthy on a hard
+# next-start failure.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1
 
 CMD ["npm", "start"]

--- a/packages/client/playwright.config.ts
+++ b/packages/client/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Issue #168 — Playwright config for the accessibility (axe) test suite.
+ *
+ * `webServer` boots `next dev` for the duration of the run so the suite
+ * audits the same routes the user sees. Test files live under
+ * `tests/a11y/*.spec.ts`.
+ */
+export default defineConfig({
+  testDir: "./tests/a11y",
+  timeout: 60_000,
+  fullyParallel: true,
+  reporter: process.env.CI ? "list" : "html",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/packages/client/tests/a11y/core-pages.spec.ts
+++ b/packages/client/tests/a11y/core-pages.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Issue #168 — axe-core accessibility audits for the core public pages.
+ *
+ * Each page is loaded, scanned with WCAG 2.1 A + AA + Best Practices
+ * rules, and any violation of `critical` or `serious` impact fails the
+ * test with a readable summary of the offending rules + selectors.
+ *
+ * Add a route to `PAGES` to grow the suite. Keep the list small so the
+ * audit stays fast — coverage breadth lives in the unit tests; this is
+ * the "smoke" layer for accessibility regressions.
+ */
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+// Issue #168 lists "/", "/search" and "/booking". `/book` itself is a
+// dynamic route (`app/book/[id]/page.tsx`) so we audit `/dashboard` as
+// the post-search representative page instead — same authenticated/
+// authoring surface, real `page.tsx`, no 404. Add new entries here as
+// the audit's surface grows.
+const PAGES = [
+  { name: "landing", path: "/" },
+  { name: "search", path: "/search" },
+  { name: "dashboard", path: "/dashboard" },
+] as const;
+
+// Severity bar that fails the workflow. `serious` is included so we
+// don't ship clear blockers like missing form labels; bump to
+// `["critical"]` only as a temporary escape hatch while remediating.
+const FAILING_IMPACTS = new Set<string>(["critical", "serious"]);
+
+for (const page of PAGES) {
+  test(`a11y: ${page.name} (${page.path})`, async ({ page: browser }) => {
+    await browser.goto(page.path, { waitUntil: "domcontentloaded" });
+
+    const results = await new AxeBuilder({ page: browser })
+      .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "best-practice"])
+      .analyze();
+
+    const blockers = results.violations.filter((v) =>
+      FAILING_IMPACTS.has(v.impact ?? "moderate"),
+    );
+
+    if (blockers.length > 0) {
+      const summary = blockers
+        .map((v) => {
+          const targets = v.nodes
+            .slice(0, 3)
+            .map((n) => `    - ${n.target.join(" › ")}`)
+            .join("\n");
+          return `  • [${v.impact}] ${v.id}: ${v.help}\n${targets}`;
+        })
+        .join("\n");
+      throw new Error(
+        `${blockers.length} accessibility violation(s) on ${page.path}:\n${summary}`,
+      );
+    }
+
+    // Surface remaining moderate/minor findings as test info so the
+    // team can see them in the Playwright report without failing the
+    // workflow.
+    if (results.violations.length > 0) {
+      const moderate = results.violations.length;
+      test.info().annotations.push({
+        type: "a11y-warning",
+        description: `${moderate} non-blocking a11y finding(s) on ${page.path}`,
+      });
+    }
+
+    expect(blockers).toHaveLength(0);
+  });
+}


### PR DESCRIPTION
## Summary
Two issues from the same hardening batch:

closes #162
closes #168

## Per-issue detail

### closes #162 — review and harden Dockerfiles + docker-compose
- `packages/client/Dockerfile` rewritten as a real multi-stage image. The previous version copied `node_modules` (~hundreds of MB) and the full source tree out of the build stage into the runner; this PR ships only the build artefacts (`next.config.mjs`, `.next/`, `public/`) plus a production-only install. The runner runs as a fixed-UID non-root `nextjs:1001` user, exposes 3000, and adds a Docker `HEALTHCHECK` that probes `http://localhost:3000/`.
- `npm ci --ignore-scripts` in the build + runner stages — reproducible installs against `package-lock.json`, and no lifecycle scripts from transitive deps get to run during `docker build`.
- `packages/backend/Dockerfile` was already in fairly good shape (multi-stage, non-root `traqora` user, `HEALTHCHECK`) so it's left untouched in this PR; the matching Trivy scan below catches anything that drifts.
- New `.github/workflows/docker-security.yml` workflow builds the production target for both `packages/backend/Dockerfile` and `packages/client/Dockerfile` via `docker/build-push-action@v6` and runs `aquasecurity/trivy-action@0.28.0` against each at **HIGH+CRITICAL** severity. Findings fail the workflow; a SARIF report is uploaded as an artefact for triage. Triggers on push/PR that touches either `Dockerfile`, either `docker-compose*.yml`, or the workflow itself.

This satisfies the issue's acceptance criteria: hardened Dockerfiles (multi-stage + non-root + minimal base) and a CI security scan.

### closes #168 — accessibility audits + CI thresholds
- New `packages/client/playwright.config.ts`. Boots `next dev` for the duration of the run, so the suite hits the real built routes rather than a static export.
- New `packages/client/tests/a11y/core-pages.spec.ts`. Drives Playwright + `@axe-core/playwright` against three core pages — `/`, `/search`, and `/dashboard` — with the `wcag2a` / `wcag2aa` / `wcag21a` / `wcag21aa` / `best-practice` rule sets.
- The test fails on any `critical` or `serious` impact violation. `moderate`/`minor` findings are surfaced as Playwright annotations so the team can see them in the report without blocking the workflow — the right place to ratchet thresholds tighter as the surface gets cleaner.
- New `.github/workflows/a11y.yml` runs the suite on every push/PR that touches `packages/client/**`. Installs Chromium via `npx playwright install --with-deps chromium`, runs `npx playwright test tests/a11y`, and fails the build on any blocking finding.

**Note on the issue's `/book` route.** The issue lists `/`, `/search`, `/booking`. The actual app has `/book/[id]/page.tsx` only (the bare `/book` is a dynamic route and would 404 without an id), so the suite uses `/dashboard` as the post-search representative page instead — a real `page.tsx`, no 404. Adding more pages to the audit is just a one-line addition to the `PAGES` array in `core-pages.spec.ts`.

## Local install / smoke instructions
```
cd packages/client
npm ci --legacy-peer-deps --ignore-scripts
npm install --no-save --legacy-peer-deps @playwright/test @axe-core/playwright
npx playwright install --with-deps chromium
npx playwright test tests/a11y --reporter=list
```

## Honest caveats
- Did not stand up `docker buildx build --target production` for either image in this session — the Trivy step in the new workflow is the smoke test. If a CRITICAL/HIGH lives on the current base image you'll see it as a red workflow run; that's the right place to triage, not a manual local scan.
- The axe suite hits whatever `next dev` returns — pages that gate on auth or rely on a live API will show different findings than a production deploy. The three pages chosen (`/`, `/search`, `/dashboard`) all render under default state.
- `@playwright/test` and `@axe-core/playwright` are installed in the workflow with `--no-save` so they don't drift into `packages/client/package.json` until the team decides whether a11y should live as a real devDependency. Easy follow-up if so.