### PR TITLE
chore(docker,a11y): harden backend Dockerfile + broaden a11y audit pages

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,64 +1,80 @@
-# Development stage
+# syntax=docker/dockerfile:1.7
+#
+# packages/backend — hardened multi-stage Node image (issue #162).
+#
+# Mirrors the hardening already applied to packages/client/Dockerfile:
+#   - Multi-stage build to drop dev deps and build toolchain from the
+#     final image
+#   - Non-root runtime user with a fixed UID
+#   - `npm ci` in build stage (deterministic from package-lock.json)
+#   - `--ignore-scripts` on install so npm lifecycle scripts can't
+#     execute untrusted code while the build is laid down
+#   - `--omit=dev` in the runner stage so devDependencies don't ship
+#   - HEALTHCHECK for Docker / k8s liveness probes
+#   - Slim alpine base, pinned to a major (use a digest in production
+#     deploys when the build pipeline supports it).
+
+# ─── Development stage (used by docker-compose.yml hot-reload) ──────────────
 FROM node:20-alpine AS development
 
 WORKDIR /usr/src/app
 
-# Install build dependencies for native modules (like sqlite3)
+# Build tools required for native modules (sqlite3, bcrypt-style libs).
 RUN apk add --no-cache python3 make g++
 
-# Install dependencies separately for better caching
 COPY package*.json ./
-RUN npm install --legacy-peer-deps
+RUN npm install --legacy-peer-deps --ignore-scripts
 
-# Copy source code (though it will be overridden by volume in docker-compose)
 COPY . .
 
-# Expose the API port
 EXPOSE 3001
+ENV NODE_ENV=development
 
-# Run the development server with hot-reload
 CMD ["npm", "run", "dev"]
 
-# Build stage
+# ─── Build stage — install + compile TypeScript ─────────────────────────────
 FROM node:20-alpine AS build
 
 WORKDIR /usr/src/app
 
-# Install build dependencies for native modules
 RUN apk add --no-cache python3 make g++
 
+# Reproducible install from package-lock.json. --ignore-scripts blocks
+# any untrusted lifecycle scripts during install; the explicit `npm run
+# build` below executes only the scripts we control.
 COPY package*.json ./
-RUN npm install --legacy-peer-deps
+RUN npm ci --legacy-peer-deps --ignore-scripts
 
 COPY . .
 RUN npm run build
 
-# Production stage
+# ─── Runner stage — minimal, non-root, healthchecked ────────────────────────
 FROM node:20-alpine AS production
 
-# Security: Add a non-root user
-RUN addgroup -S traqora && adduser -S traqora -G traqora
+# Non-root runtime user with a fixed UID for reproducibility across base
+# image rebuilds.
+RUN addgroup -g 1001 -S traqora \
+    && adduser -S -G traqora -u 1001 traqora
 
 WORKDIR /usr/src/app
 
+# Production dependencies only — no dev toolchain on the runtime image.
 COPY package*.json ./
-# Use npm ci for clean, reproducible production installs
-RUN npm ci --only=production && npm cache clean --force
+RUN npm ci --omit=dev --legacy-peer-deps --ignore-scripts \
+    && npm cache clean --force
 
-# Copy only the compiled output and necessary assets
-COPY --from=build /usr/src/app/dist ./dist
+# Built artefacts owned by the runtime user so the container can run
+# read-only-root-filesystem deployments down the road.
+COPY --from=build --chown=traqora:traqora /usr/src/app/dist ./dist
 
-# Set production environment
-ENV NODE_ENV=production
-
-# Switch to non-root user for security
 USER traqora
+
+ENV NODE_ENV=production
+ENV PORT=3001
 
 EXPOSE 3001
 
-# Healthcheck for Docker/K8s
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:3001/health || exit 1
 
 CMD ["node", "dist/index.js"]
-

--- a/packages/client/tests/a11y/core-pages.spec.ts
+++ b/packages/client/tests/a11y/core-pages.spec.ts
@@ -21,6 +21,11 @@ const PAGES = [
   { name: "landing", path: "/" },
   { name: "search", path: "/search" },
   { name: "dashboard", path: "/dashboard" },
+  // /book is a dynamic route (app/book/[id]); we audit the listings
+  // entry point that links into it instead so the suite never 404s on
+  // a placeholder id.
+  { name: "payment", path: "/payment" },
+  { name: "governance", path: "/governance" },
 ] as const;
 
 // Severity bar that fails the workflow. `serious` is included so we


### PR DESCRIPTION
## Summary

- closes #162 — applies the existing client-Dockerfile hardening pattern (from commit \`4a09433\`) to \`packages/backend/Dockerfile\`: \`npm ci\` for deterministic builds, \`--ignore-scripts\` on install, \`--omit=dev\` in the runner stage, fixed-UID non-root \`traqora\` user, \`--chown\` on copied artefacts, and the \`syntax=docker/dockerfile:1.7\` frontmatter. \`HEALTHCHECK\` + \`CMD\` unchanged. The existing Trivy workflow (\`docker-security.yml\`) and prod compose stay unmodified — they already cover the production deployment surface.
- closes #168 — broadens the axe-core audit suite. The original PR covered \`/\`, \`/search\`, \`/dashboard\`. Added \`/payment\` and \`/governance\` so the regression net catches blocker-impact violations on the two other top-level public-facing routes. \`/book\` stays skipped because it's a dynamic \`[id]\` route that would need a fixture id + network setup the workflow doesn't currently provide; recorded the reason inline in the spec.

## Notes

- I could not run \`docker build\` / \`pnpm playwright test\` locally in the build sandbox; CI is the source of truth.
- The client Dockerfile was already #162-hardened on \`main\`; this PR is the matching backend pass + the a11y suite widening.