### PR TITLE
Add analytics performance monitoring

### DIFF
--- a/packages/backend/src/monitoring/performance.ts
+++ b/packages/backend/src/monitoring/performance.ts
@@ -1,0 +1,277 @@
+import os from 'os';
+
+type OperationStatus = 'success' | 'error';
+type CacheResult = 'hit' | 'miss' | 'set' | 'fallback' | 'error';
+type AlertSeverity = 'info' | 'warning' | 'critical';
+
+interface QuerySample {
+  component: string;
+  operation: string;
+  status: OperationStatus;
+  durationMs: number;
+  timestamp: string;
+}
+
+interface CacheStats {
+  cache: string;
+  hits: number;
+  misses: number;
+  sets: number;
+  fallbacks: number;
+  errors: number;
+  totalGets: number;
+  hitRate: number;
+  averageDurationMs: number;
+}
+
+interface PerformanceAlert {
+  id: string;
+  severity: AlertSeverity;
+  metric: string;
+  message: string;
+  value: number;
+  threshold: number;
+  timestamp: string;
+}
+
+interface SlaTarget {
+  queryP95Ms: number;
+  cacheHitRate: number;
+  errorRate: number;
+}
+
+const MAX_QUERY_SAMPLES = 500;
+const MAX_ALERTS = 50;
+const DEFAULT_SLA_TARGETS: SlaTarget = {
+  queryP95Ms: 750,
+  cacheHitRate: 0.75,
+  errorRate: 0.02,
+};
+
+class PerformanceMonitor {
+  private readonly querySamples: QuerySample[] = [];
+  private readonly cacheStats = new Map<string, CacheStats & { durationTotalMs: number; operations: number }>();
+  private readonly alerts: PerformanceAlert[] = [];
+  private readonly startedAt = Date.now();
+
+  recordQuery(component: string, operation: string, status: OperationStatus, durationSeconds: number) {
+    const sample: QuerySample = {
+      component,
+      operation,
+      status,
+      durationMs: Math.round(durationSeconds * 1000),
+      timestamp: new Date().toISOString(),
+    };
+
+    this.querySamples.push(sample);
+    if (this.querySamples.length > MAX_QUERY_SAMPLES) {
+      this.querySamples.splice(0, this.querySamples.length - MAX_QUERY_SAMPLES);
+    }
+
+    if (sample.durationMs > DEFAULT_SLA_TARGETS.queryP95Ms * 2) {
+      this.addAlert('critical', 'query_latency', `${component}.${operation} exceeded latency SLA`, sample.durationMs, DEFAULT_SLA_TARGETS.queryP95Ms);
+    } else if (sample.durationMs > DEFAULT_SLA_TARGETS.queryP95Ms) {
+      this.addAlert('warning', 'query_latency', `${component}.${operation} is above latency SLA`, sample.durationMs, DEFAULT_SLA_TARGETS.queryP95Ms);
+    }
+  }
+
+  recordCache(cache: string, result: CacheResult, durationSeconds: number) {
+    const current = this.cacheStats.get(cache) ?? {
+      cache,
+      hits: 0,
+      misses: 0,
+      sets: 0,
+      fallbacks: 0,
+      errors: 0,
+      totalGets: 0,
+      hitRate: 0,
+      averageDurationMs: 0,
+      durationTotalMs: 0,
+      operations: 0,
+    };
+
+    if (result === 'hit') current.hits += 1;
+    if (result === 'miss') current.misses += 1;
+    if (result === 'set') current.sets += 1;
+    if (result === 'fallback') current.fallbacks += 1;
+    if (result === 'error') current.errors += 1;
+
+    if (result === 'hit' || result === 'miss') {
+      current.totalGets += 1;
+    }
+
+    current.durationTotalMs += durationSeconds * 1000;
+    current.operations += 1;
+    current.hitRate = current.totalGets > 0 ? current.hits / current.totalGets : 0;
+    current.averageDurationMs = current.operations > 0 ? current.durationTotalMs / current.operations : 0;
+
+    this.cacheStats.set(cache, current);
+
+    if (current.totalGets >= 20 && current.hitRate < DEFAULT_SLA_TARGETS.cacheHitRate) {
+      this.addAlert('warning', 'cache_hit_rate', `${cache} cache hit rate is below target`, current.hitRate, DEFAULT_SLA_TARGETS.cacheHitRate);
+    }
+  }
+
+  getSnapshot() {
+    const queryStats = this.buildQueryStats();
+    const cacheStats = Array.from(this.cacheStats.values()).map((stats) => ({
+      cache: stats.cache,
+      hits: stats.hits,
+      misses: stats.misses,
+      sets: stats.sets,
+      fallbacks: stats.fallbacks,
+      errors: stats.errors,
+      totalGets: stats.totalGets,
+      hitRate: round(stats.hitRate),
+      averageDurationMs: Math.round(stats.averageDurationMs),
+    }));
+    const memory = process.memoryUsage();
+    const uptimeSeconds = Math.round((Date.now() - this.startedAt) / 1000);
+    const errorRate = queryStats.totalQueries > 0 ? queryStats.errorCount / queryStats.totalQueries : 0;
+    const overallStatus = this.getOverallStatus(queryStats.p95Ms, cacheStats, errorRate);
+
+    return {
+      status: overallStatus,
+      generatedAt: new Date().toISOString(),
+      queryPerformance: queryStats,
+      cache: {
+        overallHitRate: round(calculateOverallHitRate(cacheStats)),
+        caches: cacheStats,
+      },
+      systemHealth: {
+        uptimeSeconds,
+        memoryUsageMb: {
+          rss: bytesToMb(memory.rss),
+          heapUsed: bytesToMb(memory.heapUsed),
+          heapTotal: bytesToMb(memory.heapTotal),
+        },
+        cpuLoadAverage: os.loadavg(),
+        cpuCount: os.cpus().length,
+      },
+      alerts: this.alerts.slice(-MAX_ALERTS).reverse(),
+      capacityPlanning: this.buildCapacityReport(queryStats, cacheStats, memory),
+      sla: {
+        targets: DEFAULT_SLA_TARGETS,
+        queryP95WithinSla: queryStats.p95Ms <= DEFAULT_SLA_TARGETS.queryP95Ms,
+        cacheHitRateWithinSla: calculateOverallHitRate(cacheStats) >= DEFAULT_SLA_TARGETS.cacheHitRate || cacheStats.length === 0,
+        errorRateWithinSla: errorRate <= DEFAULT_SLA_TARGETS.errorRate,
+        errorRate: round(errorRate),
+      },
+      recentQueries: this.querySamples.slice(-20).reverse(),
+    };
+  }
+
+  private buildQueryStats() {
+    const durations = this.querySamples.map((sample) => sample.durationMs).sort((a, b) => a - b);
+    const errorCount = this.querySamples.filter((sample) => sample.status === 'error').length;
+    const totalDuration = durations.reduce((sum, duration) => sum + duration, 0);
+
+    return {
+      totalQueries: this.querySamples.length,
+      errorCount,
+      averageMs: durations.length > 0 ? Math.round(totalDuration / durations.length) : 0,
+      p50Ms: percentile(durations, 0.5),
+      p95Ms: percentile(durations, 0.95),
+      p99Ms: percentile(durations, 0.99),
+      slowest: this.querySamples.reduce<QuerySample | null>((slowest, sample) => {
+        if (!slowest || sample.durationMs > slowest.durationMs) return sample;
+        return slowest;
+      }, null),
+    };
+  }
+
+  private buildCapacityReport(
+    queryStats: ReturnType<PerformanceMonitor['buildQueryStats']>,
+    cacheStats: CacheStats[],
+    memory: NodeJS.MemoryUsage
+  ) {
+    const heapUsedRatio = memory.heapTotal > 0 ? memory.heapUsed / memory.heapTotal : 0;
+    const cacheHitRate = calculateOverallHitRate(cacheStats);
+    const recommendations: string[] = [];
+
+    if (queryStats.p95Ms > DEFAULT_SLA_TARGETS.queryP95Ms) {
+      recommendations.push('Review slow analytics queries and add indexes or materialized views for repeated aggregations.');
+    }
+    if (cacheStats.length > 0 && cacheHitRate < DEFAULT_SLA_TARGETS.cacheHitRate) {
+      recommendations.push('Increase cache TTLs or pre-warm high-traffic analytics queries to improve hit rate.');
+    }
+    if (heapUsedRatio > 0.8) {
+      recommendations.push('Increase service memory limits or reduce in-memory analytics result sizes.');
+    }
+    if (recommendations.length === 0) {
+      recommendations.push('Current telemetry is within capacity targets. Continue collecting trend data for forecasting.');
+    }
+
+    return {
+      heapUsedRatio: round(heapUsedRatio),
+      projectedDailyQueries: queryStats.totalQueries * 288,
+      cacheEfficiency: round(cacheHitRate),
+      recommendations,
+    };
+  }
+
+  private getOverallStatus(queryP95Ms: number, cacheStats: CacheStats[], errorRate: number) {
+    const cacheHitRate = calculateOverallHitRate(cacheStats);
+    if (queryP95Ms > DEFAULT_SLA_TARGETS.queryP95Ms * 2 || errorRate > DEFAULT_SLA_TARGETS.errorRate * 2) {
+      return 'critical';
+    }
+    if (
+      queryP95Ms > DEFAULT_SLA_TARGETS.queryP95Ms ||
+      errorRate > DEFAULT_SLA_TARGETS.errorRate ||
+      (cacheStats.length > 0 && cacheHitRate < DEFAULT_SLA_TARGETS.cacheHitRate)
+    ) {
+      return 'degraded';
+    }
+    return 'healthy';
+  }
+
+  private addAlert(severity: AlertSeverity, metric: string, message: string, value: number, threshold: number) {
+    const last = this.alerts[this.alerts.length - 1];
+    if (last?.metric === metric && last.message === message && Date.now() - Date.parse(last.timestamp) < 60_000) {
+      return;
+    }
+
+    this.alerts.push({
+      id: `${metric}-${Date.now()}`,
+      severity,
+      metric,
+      message,
+      value: round(value),
+      threshold: round(threshold),
+      timestamp: new Date().toISOString(),
+    });
+
+    if (this.alerts.length > MAX_ALERTS) {
+      this.alerts.splice(0, this.alerts.length - MAX_ALERTS);
+    }
+  }
+}
+
+function percentile(values: number[], percentileValue: number) {
+  if (values.length === 0) return 0;
+  const index = Math.ceil(values.length * percentileValue) - 1;
+  return values[Math.max(0, Math.min(values.length - 1, index))];
+}
+
+function calculateOverallHitRate(cacheStats: CacheStats[]) {
+  const totals = cacheStats.reduce(
+    (acc, stats) => {
+      acc.hits += stats.hits;
+      acc.gets += stats.totalGets;
+      return acc;
+    },
+    { hits: 0, gets: 0 }
+  );
+
+  return totals.gets > 0 ? totals.hits / totals.gets : 0;
+}
+
+function bytesToMb(bytes: number) {
+  return Math.round(bytes / 1024 / 1024);
+}
+
+function round(value: number) {
+  return Math.round(value * 1000) / 1000;
+}
+
+export const performanceMonitor = new PerformanceMonitor();

--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { AppDataSource } from '../db/dataSource';
+import { performanceMonitor } from '../monitoring/performance';
 
 const router = Router();
 
@@ -7,6 +8,13 @@ router.get('/', async (_req, res) => {
   const db = AppDataSource.isInitialized ? 'ok' : 'unavailable';
   const status = db === 'ok' ? 200 : 503;
   res.status(status).json({ status: db === 'ok' ? 'ok' : 'degraded', db });
+});
+
+router.get('/performance', async (_req, res) => {
+  const snapshot = performanceMonitor.getSnapshot();
+  const status = snapshot.status === 'critical' ? 503 : 200;
+
+  res.status(status).json(snapshot);
 });
 
 export default router;

--- a/packages/backend/src/services/metrics.ts
+++ b/packages/backend/src/services/metrics.ts
@@ -1,5 +1,6 @@
 import { Registry, Counter, Histogram, Gauge, collectDefaultMetrics } from 'prom-client';
 import { logger } from '../utils/logger';
+import { performanceMonitor } from '../monitoring/performance';
 
 // Create a Registry to register the metrics
 export const register = new Registry();
@@ -392,14 +393,17 @@ export const measureAsync = async <T>(
   operation: string,
   fn: () => Promise<T>
 ): Promise<T> => {
+  const start = Date.now();
   const endTimer = serviceOperationDuration.startTimer({ component, operation });
 
   try {
     const result = await fn();
     endTimer({ status: 'success' });
+    performanceMonitor.recordQuery(component, operation, 'success', (Date.now() - start) / 1000);
     return result;
   } catch (error) {
     endTimer({ status: 'error' });
+    performanceMonitor.recordQuery(component, operation, 'error', (Date.now() - start) / 1000);
     throw error;
   }
 };
@@ -413,6 +417,7 @@ export const recordCacheOperation = (
   const labels = { cache, operation, result };
   cacheOperationsTotal.inc(labels);
   cacheOperationDuration.observe(labels, durationSeconds);
+  performanceMonitor.recordCache(cache, result, durationSeconds);
 };
 
 // Update uptime every 10 seconds

--- a/packages/client/app/analytics/page.tsx
+++ b/packages/client/app/analytics/page.tsx
@@ -18,7 +18,7 @@ import {
   Building2,
   Brain,
   FlaskConical,
-  ChartLine,
+  Gauge,
 } from "lucide-react"
 import { ShareButton } from "@/components/ShareButton"
 import { CommentsPanel } from "@/components/CommentsPanel"
@@ -27,6 +27,7 @@ import { Separator } from '@/components/ui/separator'
 import { RevenueForecast } from "@/components/RevenueForecast"
 import { InsightsPanel } from "@/components/InsightsPanel"
 import { ABTestConfig } from "@/components/ABTestConfig"
+import { PerformanceDashboard } from "@/components/PerformanceDashboard"
 
 interface BookingHistoryItem {
   id: string
@@ -229,6 +230,10 @@ export default function AnalyticsPage() {
               <FlaskConical className="h-4 w-4" />
               A/B Testing
             </TabsTrigger>
+            <TabsTrigger value="performance" className="flex items-center gap-2">
+              <Gauge className="h-4 w-4" />
+              Performance
+            </TabsTrigger>
           </TabsList>
 
           {/* Booking History */}
@@ -402,6 +407,11 @@ export default function AnalyticsPage() {
           {/* A/B Testing */}
           <TabsContent value="ab-testing" className="space-y-4">
             <ABTestConfig />
+          </TabsContent>
+
+          {/* Performance Monitoring */}
+          <TabsContent value="performance" className="space-y-4">
+            <PerformanceDashboard />
           </TabsContent>
         </Tabs>
 

--- a/packages/client/components/PerformanceDashboard.tsx
+++ b/packages/client/components/PerformanceDashboard.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import {
+  Activity,
+  AlertTriangle,
+  CheckCircle2,
+  Database,
+  Gauge,
+  RefreshCw,
+  Server,
+  TrendingUp,
+} from "lucide-react"
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
+import { getPerformanceSnapshot, PerformanceSnapshot } from "@/lib/api"
+
+function formatPercent(value: number) {
+  return `${Math.round(value * 100)}%`
+}
+
+function formatDuration(ms: number) {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`
+  return `${ms}ms`
+}
+
+function statusVariant(status: PerformanceSnapshot["status"]) {
+  if (status === "healthy") return "default"
+  if (status === "degraded") return "secondary"
+  return "destructive"
+}
+
+export function PerformanceDashboard() {
+  const [snapshot, setSnapshot] = useState<PerformanceSnapshot | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadSnapshot = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setSnapshot(await getPerformanceSnapshot())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to load performance metrics")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadSnapshot()
+    const interval = window.setInterval(loadSnapshot, 30000)
+    return () => window.clearInterval(interval)
+  }, [])
+
+  const latencyData = useMemo(() => {
+    if (!snapshot) return []
+    return [
+      { metric: "p50", value: snapshot.queryPerformance.p50Ms },
+      { metric: "p95", value: snapshot.queryPerformance.p95Ms },
+      { metric: "p99", value: snapshot.queryPerformance.p99Ms },
+    ]
+  }, [snapshot])
+
+  if (loading && !snapshot) {
+    return (
+      <Card>
+        <CardContent className="flex min-h-64 items-center justify-center">
+          <RefreshCw className="mr-2 h-5 w-5 animate-spin" />
+          Loading performance telemetry
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (error && !snapshot) {
+    return (
+      <Card className="border-destructive/30">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-destructive" />
+            Performance telemetry unavailable
+          </CardTitle>
+          <CardDescription>{error}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={loadSnapshot}>Retry</Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (!snapshot) return null
+
+  const heapPercent = Math.round(snapshot.capacityPlanning.heapUsedRatio * 100)
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="font-serif text-2xl font-bold text-foreground">Performance Monitoring</h2>
+          <p className="text-muted-foreground">
+            Query latency, cache efficiency, system health, alerts, and capacity planning
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Badge variant={statusVariant(snapshot.status)}>{snapshot.status.toUpperCase()}</Badge>
+          <Button variant="outline" onClick={loadSnapshot} disabled={loading}>
+            <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-muted-foreground">Query p95</p>
+                <p className="text-2xl font-bold">{formatDuration(snapshot.queryPerformance.p95Ms)}</p>
+              </div>
+              <Gauge className="h-5 w-5 text-blue-600" />
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              SLA {formatDuration(snapshot.sla.targets.queryP95Ms)}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-muted-foreground">Cache hit rate</p>
+                <p className="text-2xl font-bold">{formatPercent(snapshot.cache.overallHitRate)}</p>
+              </div>
+              <Database className="h-5 w-5 text-green-600" />
+            </div>
+            <Progress value={snapshot.cache.overallHitRate * 100} className="mt-2 h-1.5" />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-muted-foreground">Error rate</p>
+                <p className="text-2xl font-bold">{formatPercent(snapshot.sla.errorRate)}</p>
+              </div>
+              <Activity className="h-5 w-5 text-orange-600" />
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {snapshot.queryPerformance.errorCount} failed operations
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-xs text-muted-foreground">Heap usage</p>
+                <p className="text-2xl font-bold">{heapPercent}%</p>
+              </div>
+              <Server className="h-5 w-5 text-purple-600" />
+            </div>
+            <Progress value={heapPercent} className="mt-2 h-1.5" />
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-serif">Query latency distribution</CardTitle>
+            <CardDescription>
+              {snapshot.queryPerformance.totalQueries} tracked service operations
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ResponsiveContainer width="100%" height={260}>
+              <BarChart data={latencyData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="metric" />
+                <YAxis tickFormatter={(value) => `${value}ms`} />
+                <Tooltip formatter={(value) => [formatDuration(Number(value)), "Latency"]} />
+                <Bar dataKey="value" fill="#2563eb" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-serif">SLA tracking</CardTitle>
+            <CardDescription>Live checks against performance targets</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {[
+              ["Query p95 latency", snapshot.sla.queryP95WithinSla],
+              ["Cache hit rate", snapshot.sla.cacheHitRateWithinSla],
+              ["Operation error rate", snapshot.sla.errorRateWithinSla],
+            ].map(([label, passing]) => (
+              <div key={String(label)} className="flex items-center justify-between rounded-lg border p-3">
+                <span className="font-medium">{label}</span>
+                <Badge variant={passing ? "default" : "destructive"}>
+                  {passing ? "Within SLA" : "Needs attention"}
+                </Badge>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-serif">Performance alerts</CardTitle>
+            <CardDescription>Recent degradation signals generated from telemetry</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {snapshot.alerts.length === 0 ? (
+              <div className="flex items-center gap-2 rounded-lg border p-3 text-sm text-muted-foreground">
+                <CheckCircle2 className="h-4 w-4 text-green-600" />
+                No active performance alerts
+              </div>
+            ) : (
+              snapshot.alerts.slice(0, 5).map((alert) => (
+                <div key={alert.id} className="rounded-lg border p-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="font-medium">{alert.message}</p>
+                    <Badge variant={alert.severity === "critical" ? "destructive" : "secondary"}>
+                      {alert.severity}
+                    </Badge>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {alert.metric}: {alert.value} / target {alert.threshold}
+                  </p>
+                </div>
+              ))
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="font-serif">Capacity planning</CardTitle>
+            <CardDescription>
+              Projected daily query volume: {snapshot.capacityPlanning.projectedDailyQueries.toLocaleString()}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {snapshot.capacityPlanning.recommendations.map((recommendation) => (
+              <div key={recommendation} className="flex items-start gap-3 rounded-lg border p-3">
+                <TrendingUp className="mt-0.5 h-4 w-4 text-blue-600" />
+                <p className="text-sm">{recommendation}</p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/packages/client/lib/api.ts
+++ b/packages/client/lib/api.ts
@@ -64,6 +64,83 @@ export interface TransactionStatus {
   hash?: string
 }
 
+export interface PerformanceSnapshot {
+  status: 'healthy' | 'degraded' | 'critical'
+  generatedAt: string
+  queryPerformance: {
+    totalQueries: number
+    errorCount: number
+    averageMs: number
+    p50Ms: number
+    p95Ms: number
+    p99Ms: number
+    slowest: null | {
+      component: string
+      operation: string
+      status: 'success' | 'error'
+      durationMs: number
+      timestamp: string
+    }
+  }
+  cache: {
+    overallHitRate: number
+    caches: Array<{
+      cache: string
+      hits: number
+      misses: number
+      sets: number
+      fallbacks: number
+      errors: number
+      totalGets: number
+      hitRate: number
+      averageDurationMs: number
+    }>
+  }
+  systemHealth: {
+    uptimeSeconds: number
+    memoryUsageMb: {
+      rss: number
+      heapUsed: number
+      heapTotal: number
+    }
+    cpuLoadAverage: number[]
+    cpuCount: number
+  }
+  alerts: Array<{
+    id: string
+    severity: 'info' | 'warning' | 'critical'
+    metric: string
+    message: string
+    value: number
+    threshold: number
+    timestamp: string
+  }>
+  capacityPlanning: {
+    heapUsedRatio: number
+    projectedDailyQueries: number
+    cacheEfficiency: number
+    recommendations: string[]
+  }
+  sla: {
+    targets: {
+      queryP95Ms: number
+      cacheHitRate: number
+      errorRate: number
+    }
+    queryP95WithinSla: boolean
+    cacheHitRateWithinSla: boolean
+    errorRateWithinSla: boolean
+    errorRate: number
+  }
+  recentQueries: Array<{
+    component: string
+    operation: string
+    status: 'success' | 'error'
+    durationMs: number
+    timestamp: string
+  }>
+}
+
 export class ApiError extends Error {
   constructor(
     message: string,
@@ -111,6 +188,15 @@ export async function searchFlights(params: FlightSearchParams): Promise<FlightS
     if (error instanceof ApiError) throw error
     throw new ApiError(error instanceof Error ? error.message : 'Unknown error', 0)
   }
+}
+
+export async function getPerformanceSnapshot(): Promise<PerformanceSnapshot> {
+  const response = await fetch(`${API_BASE_URL}/health/performance`, { cache: 'no-store' })
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}))
+    throw new ApiError(errorData.error?.message || `HTTP ${response.status}`, response.status)
+  }
+  return response.json()
 }
 
 export const apiClient = {
@@ -162,6 +248,15 @@ export const apiClient = {
         status: 'success',
         hash: "HASH" + Math.random().toString(36).substring(2, 9).toUpperCase()
       }
+    }
+  },
+
+  getPerformanceSnapshot: async () => {
+    try {
+      const data = await getPerformanceSnapshot()
+      return { success: true, data }
+    } catch (error: any) {
+      return { success: false, error: { message: error.message } }
     }
   }
 }


### PR DESCRIPTION
Summary
- Added performance monitoring for the analytics system by turning existing service/cache telemetry into a dashboard-ready health snapshot.
- Exposed query latency, cache hit rates, SLA status, system health, performance alerts, and capacity planning recommendations.
- Added a frontend Performance tab to the existing analytics dashboard.

Issue
- Closes #262

Changes
- Added `packages/backend/src/monitoring/performance.ts`:
  - Tracks service/query execution durations from `measureAsync`.
  - Tracks cache hits, misses, sets, fallbacks, errors, hit rate, and average cache operation latency.
  - Generates performance alerts when query latency or cache hit rates degrade.
  - Computes SLA status for query p95 latency, cache hit rate, and operation error rate.
  - Reports system health data including uptime, memory usage, CPU load, and capacity recommendations.
- Wired the monitor into existing metrics helpers in `packages/backend/src/services/metrics.ts`.
- Added `GET /health/performance` in `packages/backend/src/routes/health.ts`.
- Added typed frontend API support for performance snapshots in `packages/client/lib/api.ts`.
- Added `PerformanceDashboard` with:
  - KPI cards for p95 latency, cache hit rate, error rate, and heap usage.
  - Query latency chart.
  - SLA tracking status.
  - Performance alerts.
  - Capacity planning recommendations.
- Added the dashboard as a new Performance tab in `packages/client/app/analytics/page.tsx`.

Validation
- Passed: `npm ci --ignore-scripts`.
- Passed: `git diff --check`.
- Blocked: regular `npm ci` fails on Windows because a dependency postinstall runs `yarn setup || true`; `yarn` and `true` are unavailable in this shell.
- Repo issue: backend typecheck runs but fails on existing unrelated TypeScript errors in `src/api/routes/admin/analytics.ts`, `src/api/routes/loyalty.ts`, and `src/db/tenant-scoping.ts`.
- Repo issue: client typecheck required `NODE_OPTIONS=--max-old-space-size=8192` and then failed on existing unrelated TypeScript errors across admin, analytics tenant settings, bookings, governance, loyalty, comments, wallet, tests, and flight search files.
- Repo issue: focused ESLint is blocked by the existing client ESLint config with `TypeError: Converting circular structure to JSON`.

Notes
- The monitor is intentionally in-memory and process-local, matching the current Node service topology while complementing the existing Prometheus `/metrics` endpoint.
- Existing code paths that already use `measureAsync` and `recordCacheOperation` automatically feed the new dashboard without invasive call-site changes.
