### PR TITLE
Add analytics audit logging

### DIFF
--- a/packages/backend/src/api/routes/admin/analyticsAudit.ts
+++ b/packages/backend/src/api/routes/admin/analyticsAudit.ts
@@ -1,0 +1,87 @@
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { exportAnalyticsAuditLogs, searchAnalyticsAuditLogs, writeAnalyticsAuditLog } from '../../../database/audit-log';
+import { requireAdmin, requireRole } from '../../../middleware/adminAuth';
+import { asyncHandler } from '../../../utils/errorHandler';
+
+const router = Router();
+
+const auditQuerySchema = z.object({
+  action: z.enum(['analytics_access', 'analytics_query', 'analytics_export', 'dashboard_view']).optional(),
+  actorId: z.string().optional(),
+  route: z.string().optional(),
+  tenantId: z.string().optional(),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+  limit: z.coerce.number().int().positive().max(500).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+});
+
+router.get('/audit', requireAdmin, requireRole('admin'), asyncHandler(async (req: Request, res: Response) => {
+  const filters = auditQuerySchema.parse(req.query);
+  const result = await searchAnalyticsAuditLogs(filters);
+  await writeAnalyticsAuditLog({
+    action: 'analytics_access',
+    route: '/api/v1/admin/analytics/audit',
+    method: req.method,
+    actorId: req.admin?.adminId ?? null,
+    actorEmail: req.admin?.email ?? null,
+    actorType: 'admin',
+    queryParams: filters,
+    metadata: { resultCount: result.logs.length, total: result.total },
+    statusCode: 200,
+    ipAddress: req.ip || req.socket?.remoteAddress || 'unknown',
+    userAgent: req.header('user-agent') ?? null,
+  });
+  res.json({
+    data: result.logs,
+    pagination: {
+      total: result.total,
+      limit: filters.limit ?? 100,
+      offset: filters.offset ?? 0,
+    },
+    retentionDays: 365,
+  });
+}));
+
+router.get('/audit/export', requireAdmin, requireRole('admin'), asyncHandler(async (req: Request, res: Response) => {
+  const filters = auditQuerySchema.parse(req.query);
+  const csv = await exportAnalyticsAuditLogs(filters);
+  await writeAnalyticsAuditLog({
+    action: 'analytics_export',
+    route: '/api/v1/admin/analytics/audit/export',
+    method: req.method,
+    actorId: req.admin?.adminId ?? null,
+    actorEmail: req.admin?.email ?? null,
+    actorType: 'admin',
+    queryParams: filters,
+    metadata: { exportType: 'csv' },
+    statusCode: 200,
+    ipAddress: req.ip || req.socket?.remoteAddress || 'unknown',
+    userAgent: req.header('user-agent') ?? null,
+  });
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', 'attachment; filename="analytics-audit-log.csv"');
+  res.send(csv);
+}));
+
+router.post('/audit/dashboard-view', asyncHandler(async (req: Request, res: Response) => {
+  await writeAnalyticsAuditLog({
+    action: 'dashboard_view',
+    route: String(req.body?.dashboardId || 'analytics/main'),
+    method: 'VIEW',
+    actorId: req.user?.walletAddress ?? req.admin?.adminId ?? null,
+    actorEmail: req.admin?.email ?? null,
+    actorType: req.admin ? 'admin' : req.user ? 'user' : 'anonymous',
+    tenantId: typeof req.body?.tenantId === 'string' ? req.body.tenantId : null,
+    queryParams: { dashboardId: req.body?.dashboardId },
+    metadata: { source: 'frontend' },
+    statusCode: 200,
+    durationMs: 0,
+    ipAddress: req.ip || req.socket?.remoteAddress || 'unknown',
+    userAgent: req.header('user-agent') ?? null,
+  });
+  res.status(202).json({ success: true });
+}));
+
+export const analyticsAuditRoutes = router;

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -16,6 +16,7 @@ import { adminBookingRoutes } from './api/routes/admin/bookings';
 import { adminAnalyticsRoutes } from './api/routes/admin/analytics';
 import { adminRefundRoutes } from './api/routes/admin/refunds';
 import { tenantAnalyticsRoutes } from './api/routes/admin/tenantAnalytics';
+import { analyticsAuditRoutes } from './api/routes/admin/analyticsAudit';
 import { collaborationRoutes } from './api/routes/collaboration';
 import { authRoutes } from './api/routes/auth';
 import { documentRoutes } from './api/routes/documents';
@@ -50,6 +51,7 @@ import { requireAuth } from './middleware/authMiddleware';
 import { NotFoundError } from './utils/errors';
 import { AppError } from './services/ErrorHandlingService';
 import { requestLogger } from './middleware/requestLogger';
+import { analyticsAuditLogger } from './middleware/audit-logger';
 
 export interface AppOptions {
   flightSearchService?: FlightSearchService;
@@ -182,6 +184,8 @@ export const createApp = async (options: AppOptions = {}) => {
   app.use('/api/v1/admin/flights', adminFlightRoutes);
   app.use('/api/v1/admin/users', adminUserRoutes);
   app.use('/api/v1/admin/bookings', adminBookingRoutes);
+  app.use('/api/v1/admin/analytics', analyticsAuditRoutes);
+  app.use('/api/v1/admin/analytics', analyticsAuditLogger);
   app.use('/api/v1/admin/analytics', adminAnalyticsRoutes);
   app.use('/api/v1/admin/analytics', tenantAnalyticsRoutes);
   app.use('/api/v1/admin/refunds', adminRefundRoutes);

--- a/packages/backend/src/database/audit-log.ts
+++ b/packages/backend/src/database/audit-log.ts
@@ -1,0 +1,238 @@
+import { Between, FindOptionsWhere, LessThan } from 'typeorm';
+import { AppDataSource, initDataSource } from '../db/dataSource';
+import { AnalyticsAuditAction, AnalyticsAuditLog } from '../db/entities/AnalyticsAuditLog';
+import { logger } from '../utils/logger';
+
+export const AUDIT_RETENTION_DAYS = 365;
+
+export interface AnalyticsAuditInput {
+  action: AnalyticsAuditAction;
+  route: string;
+  method: string;
+  actorId?: string | null;
+  actorEmail?: string | null;
+  actorType?: 'admin' | 'user' | 'anonymous' | 'system';
+  tenantId?: string | null;
+  queryParams?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+  statusCode?: number | null;
+  durationMs?: number | null;
+  ipAddress?: string;
+  userAgent?: string | null;
+  createdAt?: Date;
+}
+
+export interface AuditLogSearchFilters {
+  action?: AnalyticsAuditAction;
+  actorId?: string;
+  route?: string;
+  tenantId?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+  offset?: number;
+}
+
+const memoryLogs: AnalyticsAuditLog[] = [];
+
+export async function writeAnalyticsAuditLog(input: AnalyticsAuditInput): Promise<void> {
+  const log = normalizeLog(input);
+  memoryLogs.push(log);
+  pruneMemoryLogs();
+
+  try {
+    await initDataSource();
+    if (!AppDataSource.isInitialized) return;
+
+    const repo = AppDataSource.getRepository(AnalyticsAuditLog);
+    await repo.save(repo.create({
+      ...log,
+      queryParams: log.queryParams,
+      metadata: log.metadata,
+    }));
+  } catch (error) {
+    logger.warn('Failed to persist analytics audit log', {
+      action: input.action,
+      route: input.route,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function searchAnalyticsAuditLogs(filters: AuditLogSearchFilters = {}) {
+  await enforceAuditRetention();
+
+  try {
+    await initDataSource();
+    if (AppDataSource.isInitialized) {
+      const repo = AppDataSource.getRepository(AnalyticsAuditLog);
+      const where = buildWhere(filters);
+      const [logs, total] = await repo.findAndCount({
+        where,
+        order: { createdAt: 'DESC' },
+        take: clampLimit(filters.limit),
+        skip: filters.offset ?? 0,
+      });
+      return { logs: logs.map(serializeLog), total };
+    }
+  } catch (error) {
+    logger.warn('Falling back to in-memory analytics audit search', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const filtered = filterMemoryLogs(filters);
+  return {
+    logs: filtered.slice(filters.offset ?? 0, (filters.offset ?? 0) + clampLimit(filters.limit)).map(serializeLog),
+    total: filtered.length,
+  };
+}
+
+export async function exportAnalyticsAuditLogs(filters: AuditLogSearchFilters = {}) {
+  const result = await searchAnalyticsAuditLogs({ ...filters, limit: 10_000, offset: 0 });
+  const rows = result.logs;
+  const header = [
+    'id',
+    'createdAt',
+    'action',
+    'actorType',
+    'actorId',
+    'actorEmail',
+    'tenantId',
+    'method',
+    'route',
+    'statusCode',
+    'durationMs',
+    'ipAddress',
+    'userAgent',
+    'queryParams',
+    'metadata',
+  ];
+
+  return [
+    header.join(','),
+    ...rows.map((row) => header.map((key) => csvEscape(String(row[key as keyof typeof row] ?? ''))).join(',')),
+  ].join('\n');
+}
+
+export async function enforceAuditRetention(): Promise<void> {
+  pruneMemoryLogs();
+
+  try {
+    await initDataSource();
+    if (!AppDataSource.isInitialized) return;
+    const cutoff = retentionCutoff();
+    await AppDataSource.getRepository(AnalyticsAuditLog).delete({ createdAt: LessThan(cutoff) });
+  } catch (error) {
+    logger.warn('Failed to enforce analytics audit retention', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function normalizeLog(input: AnalyticsAuditInput): AnalyticsAuditLog {
+  const now = input.createdAt ?? new Date();
+  return {
+    id: `${now.getTime()}-${Math.random().toString(36).slice(2, 10)}`,
+    action: input.action,
+    route: input.route,
+    method: input.method.toUpperCase(),
+    actorId: input.actorId ?? null,
+    actorEmail: input.actorEmail ?? null,
+    actorType: input.actorType ?? 'anonymous',
+    tenantId: input.tenantId ?? null,
+    queryParams: stringifySafe(input.queryParams),
+    metadata: stringifySafe(input.metadata),
+    statusCode: input.statusCode ?? null,
+    durationMs: input.durationMs ?? null,
+    ipAddress: input.ipAddress ?? 'unknown',
+    userAgent: input.userAgent ?? null,
+    createdAt: now,
+  };
+}
+
+function buildWhere(filters: AuditLogSearchFilters): FindOptionsWhere<AnalyticsAuditLog> {
+  const where: FindOptionsWhere<AnalyticsAuditLog> = {};
+  if (filters.action) where.action = filters.action;
+  if (filters.actorId) where.actorId = filters.actorId;
+  if (filters.route) where.route = filters.route;
+  if (filters.tenantId) where.tenantId = filters.tenantId;
+  if (filters.from || filters.to) {
+    where.createdAt = Between(
+      filters.from ? new Date(filters.from) : new Date(0),
+      filters.to ? new Date(filters.to) : new Date()
+    );
+  }
+  return where;
+}
+
+function filterMemoryLogs(filters: AuditLogSearchFilters) {
+  return memoryLogs
+    .filter((log) => !filters.action || log.action === filters.action)
+    .filter((log) => !filters.actorId || log.actorId === filters.actorId)
+    .filter((log) => !filters.route || log.route === filters.route)
+    .filter((log) => !filters.tenantId || log.tenantId === filters.tenantId)
+    .filter((log) => !filters.from || log.createdAt >= new Date(filters.from))
+    .filter((log) => !filters.to || log.createdAt <= new Date(filters.to))
+    .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+}
+
+function serializeLog(log: AnalyticsAuditLog) {
+  return {
+    id: log.id,
+    action: log.action,
+    route: log.route,
+    method: log.method,
+    actorId: log.actorId,
+    actorEmail: log.actorEmail,
+    actorType: log.actorType,
+    tenantId: log.tenantId,
+    queryParams: log.queryParams,
+    metadata: log.metadata,
+    statusCode: log.statusCode,
+    durationMs: log.durationMs,
+    ipAddress: log.ipAddress,
+    userAgent: log.userAgent,
+    createdAt: log.createdAt.toISOString(),
+  };
+}
+
+function pruneMemoryLogs() {
+  const cutoff = retentionCutoff().getTime();
+  for (let index = memoryLogs.length - 1; index >= 0; index -= 1) {
+    if (memoryLogs[index].createdAt.getTime() < cutoff) {
+      memoryLogs.splice(index, 1);
+    }
+  }
+}
+
+function retentionCutoff() {
+  return new Date(Date.now() - AUDIT_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+}
+
+function stringifySafe(value?: Record<string, unknown> | null) {
+  if (!value) return null;
+  return JSON.stringify(redactSecrets(value));
+}
+
+function redactSecrets(value: Record<string, unknown>): Record<string, unknown> {
+  const redacted: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (/token|secret|password|authorization|api[-_]?key/i.test(key)) {
+      redacted[key] = '[redacted]';
+    } else {
+      redacted[key] = entry;
+    }
+  }
+  return redacted;
+}
+
+function clampLimit(limit?: number) {
+  if (!limit || Number.isNaN(limit)) return 100;
+  return Math.min(Math.max(limit, 1), 500);
+}
+
+function csvEscape(value: string) {
+  const escaped = value.replace(/"/g, '""');
+  return `"${escaped}"`;
+}

--- a/packages/backend/src/db/dataSource.ts
+++ b/packages/backend/src/db/dataSource.ts
@@ -16,6 +16,7 @@ import { TravelDocument } from "./entities/TravelDocument";
 import { Tenant } from "./entities/Tenant";
 import { DashboardShare } from "./entities/DashboardShare";
 import { DashboardComment } from "./entities/DashboardComment";
+import { AnalyticsAuditLog } from "./entities/AnalyticsAuditLog";
 
 const isTest = process.env.NODE_ENV === "test";
 
@@ -41,6 +42,7 @@ export const AppDataSource = new DataSource(
         Tenant,
         DashboardShare,
         DashboardComment,
+        AnalyticsAuditLog,
       ],
       logging: false,
     }
@@ -64,6 +66,7 @@ export const AppDataSource = new DataSource(
         Tenant,
         DashboardShare,
         DashboardComment,
+        AnalyticsAuditLog,
       ],
       migrations: [__dirname + "/migrations/*.{js,ts}"],
       ssl:

--- a/packages/backend/src/db/entities/AnalyticsAuditLog.ts
+++ b/packages/backend/src/db/entities/AnalyticsAuditLog.ts
@@ -1,0 +1,65 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+export type AnalyticsAuditAction =
+  | 'analytics_access'
+  | 'analytics_query'
+  | 'analytics_export'
+  | 'dashboard_view';
+
+@Entity({ name: 'analytics_audit_logs' })
+export class AnalyticsAuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Index()
+  @Column({ type: 'varchar', length: 64 })
+  action!: AnalyticsAuditAction;
+
+  @Index()
+  @Column({ type: 'varchar', length: 256 })
+  route!: string;
+
+  @Column({ type: 'varchar', length: 16 })
+  method!: string;
+
+  @Index()
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  actorId?: string | null;
+
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  actorEmail?: string | null;
+
+  @Column({ type: 'varchar', length: 32, default: 'unknown' })
+  actorType!: 'admin' | 'user' | 'anonymous' | 'system';
+
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  tenantId?: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  queryParams?: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  metadata?: string | null;
+
+  @Column({ type: 'integer', nullable: true })
+  statusCode?: number | null;
+
+  @Column({ type: 'integer', nullable: true })
+  durationMs?: number | null;
+
+  @Column({ type: 'varchar', length: 64, default: 'unknown' })
+  ipAddress!: string;
+
+  @Column({ type: 'varchar', length: 256, nullable: true })
+  userAgent?: string | null;
+
+  @Index()
+  @CreateDateColumn({ type: process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamptz' })
+  createdAt!: Date;
+}

--- a/packages/backend/src/db/migrations/1750000000002-CreateAnalyticsAuditLogs.ts
+++ b/packages/backend/src/db/migrations/1750000000002-CreateAnalyticsAuditLogs.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAnalyticsAuditLogs1750000000002 implements MigrationInterface {
+  name = 'CreateAnalyticsAuditLogs1750000000002';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "analytics_audit_logs" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        "action" varchar(64) NOT NULL,
+        "route" varchar(256) NOT NULL,
+        "method" varchar(16) NOT NULL,
+        "actorId" varchar(128),
+        "actorEmail" varchar(128),
+        "actorType" varchar(32) NOT NULL DEFAULT 'unknown',
+        "tenantId" varchar(128),
+        "queryParams" text,
+        "metadata" text,
+        "statusCode" integer,
+        "durationMs" integer,
+        "ipAddress" varchar(64) NOT NULL DEFAULT 'unknown',
+        "userAgent" varchar(256),
+        "createdAt" timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS "idx_analytics_audit_logs_action" ON "analytics_audit_logs" ("action")`);
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS "idx_analytics_audit_logs_route" ON "analytics_audit_logs" ("route")`);
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS "idx_analytics_audit_logs_actorId" ON "analytics_audit_logs" ("actorId")`);
+    await queryRunner.query(`CREATE INDEX IF NOT EXISTS "idx_analytics_audit_logs_createdAt" ON "analytics_audit_logs" ("createdAt")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_analytics_audit_logs_createdAt"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_analytics_audit_logs_actorId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_analytics_audit_logs_route"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_analytics_audit_logs_action"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "analytics_audit_logs"`);
+  }
+}

--- a/packages/backend/src/middleware/audit-logger.ts
+++ b/packages/backend/src/middleware/audit-logger.ts
@@ -1,0 +1,70 @@
+import { NextFunction, Request, Response } from 'express';
+import { writeAnalyticsAuditLog } from '../database/audit-log';
+import { AnalyticsAuditAction } from '../db/entities/AnalyticsAuditLog';
+
+const ANALYTICS_PATH_PATTERN = /\/analytics(\/|$)/i;
+
+export function analyticsAuditLogger(req: Request, res: Response, next: NextFunction): void {
+  const startedAt = Date.now();
+
+  res.on('finish', () => {
+    if (!shouldAudit(req)) return;
+
+    const action = classifyAction(req);
+    const admin = req.admin;
+    const user = req.user;
+
+    void writeAnalyticsAuditLog({
+      action,
+      route: req.originalUrl?.split('?')[0] || req.path,
+      method: req.method,
+      actorId: admin?.adminId ?? user?.walletAddress ?? null,
+      actorEmail: admin?.email ?? null,
+      actorType: admin ? 'admin' : user ? 'user' : 'anonymous',
+      tenantId: extractTenantId(req),
+      queryParams: normalizeParams(req),
+      metadata: {
+        dashboardId: req.body?.dashboardId,
+        exportJobId: req.params?.id,
+        statusMessage: res.statusMessage,
+      },
+      statusCode: res.statusCode,
+      durationMs: Date.now() - startedAt,
+      ipAddress: req.ip || req.socket?.remoteAddress || 'unknown',
+      userAgent: req.header('user-agent') ?? null,
+    });
+  });
+
+  next();
+}
+
+function shouldAudit(req: Request) {
+  return ANALYTICS_PATH_PATTERN.test(req.originalUrl || req.path);
+}
+
+function classifyAction(req: Request): AnalyticsAuditAction {
+  const path = req.originalUrl || req.path;
+  if (/dashboard-view/i.test(path) || req.body?.event === 'dashboard_view') {
+    return 'dashboard_view';
+  }
+  if (/export/i.test(path)) {
+    return 'analytics_export';
+  }
+  if (req.method.toUpperCase() === 'GET') {
+    return 'analytics_query';
+  }
+  return 'analytics_access';
+}
+
+function extractTenantId(req: Request) {
+  const value = req.params?.tenantId || req.query?.tenantId || req.body?.tenantId;
+  return typeof value === 'string' ? value : null;
+}
+
+function normalizeParams(req: Request) {
+  return {
+    query: req.query,
+    params: req.params,
+    body: req.method.toUpperCase() === 'GET' ? undefined : req.body,
+  };
+}

--- a/packages/client/app/analytics/audit/page.tsx
+++ b/packages/client/app/analytics/audit/page.tsx
@@ -1,0 +1,244 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import { Download, Eye, Filter, RefreshCw, ShieldCheck } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+
+type AuditAction = "all" | "analytics_access" | "analytics_query" | "analytics_export" | "dashboard_view"
+
+interface AuditLogRow {
+  id: string
+  action: Exclude<AuditAction, "all">
+  route: string
+  method: string
+  actorId: string | null
+  actorEmail: string | null
+  actorType: string
+  tenantId: string | null
+  queryParams: string | null
+  metadata: string | null
+  statusCode: number | null
+  durationMs: number | null
+  ipAddress: string
+  userAgent: string | null
+  createdAt: string
+}
+
+interface AuditResponse {
+  data: AuditLogRow[]
+  pagination: {
+    total: number
+    limit: number
+    offset: number
+  }
+  retentionDays: number
+}
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001"
+
+function adminHeaders(): Record<string, string> {
+  if (typeof window === "undefined") return {}
+  const apiKey = localStorage.getItem("adminApiKey")
+  const token = localStorage.getItem("authToken")
+  if (apiKey) return { "X-Admin-Api-Key": apiKey }
+  if (token) return { Authorization: `Bearer ${token}` }
+  return {}
+}
+
+function actionVariant(action: AuditLogRow["action"]) {
+  if (action === "analytics_export") return "destructive"
+  if (action === "dashboard_view") return "secondary"
+  return "default"
+}
+
+export default function AuditLogViewerPage() {
+  const [rows, setRows] = useState<AuditLogRow[]>([])
+  const [action, setAction] = useState<AuditAction>("all")
+  const [actorId, setActorId] = useState("")
+  const [route, setRoute] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [total, setTotal] = useState(0)
+  const [retentionDays, setRetentionDays] = useState(365)
+
+  const query = useMemo(() => {
+    const params = new URLSearchParams({ limit: "100" })
+    if (action !== "all") params.set("action", action)
+    if (actorId.trim()) params.set("actorId", actorId.trim())
+    if (route.trim()) params.set("route", route.trim())
+    return params
+  }, [action, actorId, route])
+
+  const loadLogs = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/v1/admin/analytics/audit?${query.toString()}`, {
+        headers: adminHeaders(),
+      })
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const data = (await response.json()) as AuditResponse
+      setRows(data.data)
+      setTotal(data.pagination.total)
+      setRetentionDays(data.retentionDays)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load audit logs")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const exportLogs = () => {
+    window.open(`${API_BASE_URL}/api/v1/admin/analytics/audit/export?${query.toString()}`, "_blank", "noopener,noreferrer")
+  }
+
+  useEffect(() => {
+    loadLogs()
+    void fetch(`${API_BASE_URL}/api/v1/admin/analytics/audit/dashboard-view`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...adminHeaders() },
+      body: JSON.stringify({ dashboardId: "analytics/audit" }),
+    }).catch(() => undefined)
+  }, [query])
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="mb-2 flex items-center gap-2">
+              <ShieldCheck className="h-7 w-7 text-primary" />
+              <h1 className="font-serif text-3xl font-bold text-foreground">Analytics Audit Logs</h1>
+            </div>
+            <p className="text-muted-foreground">
+              Review analytics access, query parameters, dashboard views, and export activity.
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={loadLogs} disabled={loading}>
+              <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+              Refresh
+            </Button>
+            <Button onClick={exportLogs}>
+              <Download className="mr-2 h-4 w-4" />
+              Export CSV
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <Card>
+            <CardContent className="p-4">
+              <p className="text-sm text-muted-foreground">Total matching events</p>
+              <p className="text-2xl font-bold">{total.toLocaleString()}</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4">
+              <p className="text-sm text-muted-foreground">Retention policy</p>
+              <p className="text-2xl font-bold">{retentionDays} days</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4">
+              <p className="text-sm text-muted-foreground">Visible rows</p>
+              <p className="text-2xl font-bold">{rows.length}</p>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 font-serif">
+              <Filter className="h-5 w-5" />
+              Filters
+            </CardTitle>
+            <CardDescription>Search audit events by action, actor, or exact route.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid gap-4 md:grid-cols-3">
+            <div className="space-y-2">
+              <Label htmlFor="action">Action</Label>
+              <Select value={action} onValueChange={(value) => setAction(value as AuditAction)}>
+                <SelectTrigger id="action">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All actions</SelectItem>
+                  <SelectItem value="analytics_access">Access</SelectItem>
+                  <SelectItem value="analytics_query">Query</SelectItem>
+                  <SelectItem value="analytics_export">Export</SelectItem>
+                  <SelectItem value="dashboard_view">Dashboard view</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="actor">Actor ID</Label>
+              <Input id="actor" value={actorId} onChange={(event) => setActorId(event.target.value)} placeholder="admin id or wallet" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="route">Route</Label>
+              <Input id="route" value={route} onChange={(event) => setRoute(event.target.value)} placeholder="/api/v1/admin/analytics" />
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 font-serif">
+              <Eye className="h-5 w-5" />
+              Audit Trail
+            </CardTitle>
+            {error && <CardDescription className="text-destructive">{error}</CardDescription>}
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Time</TableHead>
+                  <TableHead>Action</TableHead>
+                  <TableHead>Actor</TableHead>
+                  <TableHead>Route</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Query Params</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.id}>
+                    <TableCell className="whitespace-nowrap text-sm">{new Date(row.createdAt).toLocaleString()}</TableCell>
+                    <TableCell>
+                      <Badge variant={actionVariant(row.action)}>{row.action}</Badge>
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      <div>{row.actorId || "anonymous"}</div>
+                      <div className="text-xs text-muted-foreground">{row.actorType}</div>
+                    </TableCell>
+                    <TableCell className="min-w-64 text-sm">
+                      <div className="font-medium">{row.method} {row.route}</div>
+                      <div className="text-xs text-muted-foreground">{row.durationMs ?? 0}ms</div>
+                    </TableCell>
+                    <TableCell>{row.statusCode ?? "-"}</TableCell>
+                    <TableCell className="max-w-80 truncate font-mono text-xs">{row.queryParams || "{}"}</TableCell>
+                  </TableRow>
+                ))}
+                {rows.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
+                      No audit events match the selected filters.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/packages/client/app/analytics/page.tsx
+++ b/packages/client/app/analytics/page.tsx
@@ -7,7 +7,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import {
   Plane,
   Calendar,
-  MapPin,
   TrendingUp,
   Leaf,
   BarChart3,
@@ -18,7 +17,7 @@ import {
   Building2,
   Brain,
   FlaskConical,
-  ChartLine,
+  ShieldCheck,
 } from "lucide-react"
 import { ShareButton } from "@/components/ShareButton"
 import { CommentsPanel } from "@/components/CommentsPanel"
@@ -62,6 +61,7 @@ interface UserAnalytics {
 }
 
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8'];
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001"
 
 export default function AnalyticsPage() {
   const [loading, setLoading] = useState(true)
@@ -116,6 +116,14 @@ export default function AnalyticsPage() {
       setAnalytics(mockAnalytics)
       setLoading(false)
     }, 1000)
+  }, [])
+
+  useEffect(() => {
+    void fetch(`${API_BASE_URL}/api/v1/admin/analytics/audit/dashboard-view`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ dashboardId: "analytics/main" }),
+    }).catch(() => undefined)
   }, [])
 
   if (loading) {
@@ -176,6 +184,10 @@ export default function AnalyticsPage() {
             <a href="/analytics/tenant-settings" className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground border rounded-md px-3 py-1.5 transition-colors">
               <Building2 className="h-4 w-4" />
               Tenant
+            </a>
+            <a href="/analytics/audit" className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground border rounded-md px-3 py-1.5 transition-colors">
+              <ShieldCheck className="h-4 w-4" />
+              Audit
             </a>
             <ShareButton dashboardId="analytics/main" />
           </div>


### PR DESCRIPTION
Summary
- Added comprehensive audit logging for analytics access, queries, exports, and dashboard views.
- Added a searchable/exportable audit-log backend with one-year retention.
- Added a frontend audit log viewer under the analytics area.

Issue
- Closes #257

Changes
- Added `AnalyticsAuditLog` entity and production migration for `analytics_audit_logs`.
- Added analytics audit storage in `packages/backend/src/database/audit-log.ts`:
  - Persisted audit writes when TypeORM is initialized.
  - In-memory fallback for dev/test environments without a configured database.
  - Search and filter by action, actor, route, tenant, and date range.
  - CSV export support.
  - 365-day retention cleanup.
- Added `analyticsAuditLogger` middleware:
  - Logs analytics API access.
  - Captures query params, route params, non-GET body metadata, actor, status, duration, IP, and user agent.
  - Classifies analytics query, export, access, and dashboard-view events.
- Added admin audit endpoints:
  - `GET /api/v1/admin/analytics/audit`
  - `GET /api/v1/admin/analytics/audit/export`
  - `POST /api/v1/admin/analytics/audit/dashboard-view`
- Mounted audit middleware before existing analytics routers so active analytics API calls are captured.
- Added `/analytics/audit` frontend viewer with filters, retention summary, audit table, and CSV export action.
- Added dashboard-view logging from `/analytics` and a link to the audit viewer.

Validation
- Passed: `npm ci --ignore-scripts`.
- Passed: `git diff --check`.
- Repo issue: backend typecheck runs but fails on existing unrelated TypeScript errors in `src/api/routes/admin/analytics.ts`, `src/api/routes/loyalty.ts`, and `src/db/tenant-scoping.ts`.
- Repo issue: client typecheck required `NODE_OPTIONS=--max-old-space-size=8192` and then failed on existing unrelated TypeScript errors across admin, tenant settings, booking, governance, loyalty, comments, wallet, tests, and flight-search files.

Notes
- Normal `npm ci` was not used because this repository has a Windows-incompatible transitive postinstall script that invokes `yarn setup || true`.
- Audit log retention is enforced at read/write time and deletes records older than 365 days when the database is available.
