### PR TITLE
feat(a11y): add WCAG 2.1 AA semantic landmarks and skip navigation

### DIFF
--- a/packages/client/app/layout.tsx
+++ b/packages/client/app/layout.tsx
@@ -11,6 +11,7 @@ import { ConnectionIndicator } from "@/components/connection-indicator";
 // NEW: WalletProvider to initialise StellarWalletsKit on app mount
 import { WalletProvider } from "@/components/wallet-provider";
 import { OfflineProvider } from "@/components/offline-provider";
+import { SkipNav } from "@/components/skip-nav";
 
 const playfairDisplay = Playfair_Display({
   subsets: ["latin"],
@@ -44,6 +45,8 @@ export default function RootLayout({
       className={`${playfairDisplay.variable} ${sourceSansPro.variable} antialiased`}
     >
       <body className="font-sans">
+        {/* Skip navigation link — first focusable element for keyboard users (WCAG 2.4.1) */}
+        <SkipNav />
         {/* Nesting providers ensures both Wallet and Socket functionality are available app-wide */}
         <OfflineProvider>
           <WalletProvider>

--- a/packages/client/app/page.tsx
+++ b/packages/client/app/page.tsx
@@ -20,105 +20,138 @@ export default function HomePage() {
     if (searchData.return) {
       params.set('return', searchData.return)
     }
-    
+
     router.push(`/search?${params.toString()}`)
   }
 
   return (
     <div className="min-h-screen bg-background">
-      {/* Navigation */}
-      <nav className="border-b border-border bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <div className="flex items-center space-x-2">
-              <Plane className="h-8 w-8 text-primary" />
-              <span className="font-serif font-bold text-2xl text-foreground">Traqora</span>
-            </div>
-            
-            <div className="flex items-center space-x-4">
-              <Link href="/search">
-                <Button variant="outline">Browse Flights</Button>
-              </Link>
-              <Link href="/auth">
-                <Button>Sign In</Button>
-              </Link>
+      {/* Navigation — landmark: banner */}
+      <header role="banner">
+        <nav
+          aria-label="Main navigation"
+          className="border-b border-border bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60"
+        >
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div className="flex justify-between items-center h-16">
+              <div className="flex items-center space-x-2">
+                {/* Decorative icon — hidden from assistive technology */}
+                <Plane className="h-8 w-8 text-primary" aria-hidden="true" />
+                <span className="font-serif font-bold text-2xl text-foreground">Traqora</span>
+              </div>
+
+              <div className="flex items-center space-x-4">
+                <Link href="/search">
+                  <Button variant="outline">Browse Flights</Button>
+                </Link>
+                <Link href="/auth">
+                  <Button>Sign In</Button>
+                </Link>
+              </div>
             </div>
           </div>
-        </div>
-      </nav>
+        </nav>
+      </header>
 
-      {/* Hero Section */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <div className="text-center mb-12">
-          <h1 className="text-4xl md:text-6xl font-serif font-bold text-foreground mb-6">
-            Decentralized Flight Booking
-          </h1>
-          <p className="text-xl text-muted-foreground max-w-3xl mx-auto mb-8">
-            Book flights directly with airlines using blockchain technology. 
-            No intermediaries, transparent pricing, automated refunds.
-          </p>
-        </div>
-
-        {/* Search Form */}
-        <div className="mb-16">
-          <SearchForm onSearch={handleSearch} />
-        </div>
-
-        {/* Features */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-16">
-          <Card className="border-0 bg-card/50 backdrop-blur-sm">
-            <CardContent className="p-6 text-center">
-              <Zap className="h-12 w-12 text-primary mx-auto mb-4" />
-              <h3 className="text-xl font-semibold mb-2">Instant Booking</h3>
-              <p className="text-muted-foreground">
-                Book flights instantly with cryptocurrency payments and smart contract automation.
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card className="border-0 bg-card/50 backdrop-blur-sm">
-            <CardContent className="p-6 text-center">
-              <Shield className="h-12 w-12 text-primary mx-auto mb-4" />
-              <h3 className="text-xl font-semibold mb-2">Automated Refunds</h3>
-              <p className="text-muted-foreground">
-                Smart contracts automatically process refunds for delays and cancellations.
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card className="border-0 bg-card/50 backdrop-blur-sm">
-            <CardContent className="p-6 text-center">
-              <Globe className="h-12 w-12 text-primary mx-auto mb-4" />
-              <h3 className="text-xl font-semibold mb-2">Global Access</h3>
-              <p className="text-muted-foreground">
-                Access flights worldwide with transparent pricing and no hidden fees.
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-
-        {/* Popular Routes */}
-        <div className="text-center">
-          <h2 className="text-2xl font-serif font-bold mb-8">Popular Routes</h2>
-          <div className="flex flex-wrap justify-center gap-4">
-            {[
-              { from: "JFK", to: "LAX", route: "New York → Los Angeles" },
-              { from: "ORD", to: "MIA", route: "Chicago → Miami" },
-              { from: "SFO", to: "SEA", route: "San Francisco → Seattle" },
-              { from: "DEN", to: "LAS", route: "Denver → Las Vegas" },
-            ].map((route) => (
-              <Link
-                key={`${route.from}-${route.to}`}
-                href={`/search?from=${route.from}&to=${route.to}&departure=${new Date(Date.now() + 86400000).toISOString().split('T')[0]}&passengers=1&class=economy`}
-              >
-                <Button variant="outline" className="hover:bg-primary hover:text-primary-foreground">
-                  {route.route}
-                </Button>
-              </Link>
-            ))}
+      {/* Primary content — landmark: main; id target for skip-nav */}
+      <main id="main-content" tabIndex={-1} className="outline-none">
+        {/* Hero Section */}
+        <section
+          aria-labelledby="hero-heading"
+          className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16"
+        >
+          <div className="text-center mb-12">
+            <h1
+              id="hero-heading"
+              className="text-4xl md:text-6xl font-serif font-bold text-foreground mb-6"
+            >
+              Decentralized Flight Booking
+            </h1>
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto mb-8">
+              Book flights directly with airlines using blockchain technology.{" "}
+              No intermediaries, transparent pricing, automated refunds.
+            </p>
           </div>
-        </div>
-      </div>
+
+          {/* Search Form */}
+          <div className="mb-16">
+            <SearchForm onSearch={handleSearch} />
+          </div>
+
+          {/* Features */}
+          <section aria-labelledby="features-heading" className="mb-16">
+            <h2 id="features-heading" className="sr-only">Platform features</h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+              <Card className="border-0 bg-card/50 backdrop-blur-sm">
+                <CardContent className="p-6 text-center">
+                  <Zap className="h-12 w-12 text-primary mx-auto mb-4" aria-hidden="true" />
+                  <h3 className="text-xl font-semibold mb-2">Instant Booking</h3>
+                  <p className="text-muted-foreground">
+                    Book flights instantly with cryptocurrency payments and smart contract automation.
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card className="border-0 bg-card/50 backdrop-blur-sm">
+                <CardContent className="p-6 text-center">
+                  <Shield className="h-12 w-12 text-primary mx-auto mb-4" aria-hidden="true" />
+                  <h3 className="text-xl font-semibold mb-2">Automated Refunds</h3>
+                  <p className="text-muted-foreground">
+                    Smart contracts automatically process refunds for delays and cancellations.
+                  </p>
+                </CardContent>
+              </Card>
+
+              <Card className="border-0 bg-card/50 backdrop-blur-sm">
+                <CardContent className="p-6 text-center">
+                  <Globe className="h-12 w-12 text-primary mx-auto mb-4" aria-hidden="true" />
+                  <h3 className="text-xl font-semibold mb-2">Global Access</h3>
+                  <p className="text-muted-foreground">
+                    Access flights worldwide with transparent pricing and no hidden fees.
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+          </section>
+
+          {/* Popular Routes */}
+          <section aria-labelledby="popular-routes-heading" className="text-center">
+            <h2
+              id="popular-routes-heading"
+              className="text-2xl font-serif font-bold mb-8"
+            >
+              Popular Routes
+            </h2>
+            <div className="flex flex-wrap justify-center gap-4" role="list">
+              {[
+                { from: "JFK", to: "LAX", route: "New York → Los Angeles" },
+                { from: "ORD", to: "MIA", route: "Chicago → Miami" },
+                { from: "SFO", to: "SEA", route: "San Francisco → Seattle" },
+                { from: "DEN", to: "LAS", route: "Denver → Las Vegas" },
+              ].map((r) => (
+                <div key={`${r.from}-${r.to}`} role="listitem">
+                  <Link
+                    href={`/search?from=${r.from}&to=${r.to}&departure=${new Date(Date.now() + 86400000).toISOString().split('T')[0]}&passengers=1&class=economy`}
+                    aria-label={`Search flights: ${r.route}`}
+                  >
+                    <Button
+                      variant="outline"
+                      className="hover:bg-primary hover:text-primary-foreground"
+                    >
+                      {r.route}
+                    </Button>
+                  </Link>
+                </div>
+              ))}
+            </div>
+          </section>
+        </section>
+      </main>
+
+      {/* Footer — landmark: contentinfo */}
+      <footer role="contentinfo" className="sr-only">
+        <p>© {new Date().getFullYear()} Traqora. Decentralized flight booking powered by Stellar.</p>
+      </footer>
     </div>
   )
 }

--- a/packages/client/components/home-nav.tsx
+++ b/packages/client/components/home-nav.tsx
@@ -17,12 +17,18 @@ export function HomeNav() {
   const { isConnected } = useWalletStore()
 
   return (
-    <nav className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-xl border-b border-border">
+    <nav
+      aria-label="Main navigation"
+      className="fixed top-0 left-0 right-0 z-50 bg-background/80 backdrop-blur-xl border-b border-border"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-20">
           {/* Logo */}
           <div className="flex items-center space-x-3">
-            <div className="w-10 h-10 bg-gradient-to-br from-primary to-primary/80 rounded-xl flex items-center justify-center shadow-lg">
+            <div
+              className="w-10 h-10 bg-gradient-to-br from-primary to-primary/80 rounded-xl flex items-center justify-center shadow-lg"
+              aria-hidden="true"
+            >
               <Plane className="h-6 w-6 text-primary-foreground" />
             </div>
             <span className="font-serif font-black text-2xl text-foreground">Traqora</span>

--- a/packages/client/components/skip-nav.tsx
+++ b/packages/client/components/skip-nav.tsx
@@ -1,0 +1,30 @@
+/**
+ * SkipNav — keyboard skip-navigation link (WCAG 2.4.1 Bypass Blocks).
+ *
+ * Rendered as the very first focusable element in the document. Visually
+ * hidden until focused; activating it jumps keyboard focus directly to the
+ * main content region, bypassing the repeated navigation bar.
+ *
+ * Usage:
+ *   1. Mount <SkipNav /> as the first child of <body>.
+ *   2. Add `id="main-content"` to the primary <main> element.
+ */
+export function SkipNav() {
+  return (
+    <a
+      href="#main-content"
+      className={[
+        // Hidden off-screen by default
+        "absolute -top-full left-4 z-[9999]",
+        // Visible and in-flow when focused
+        "focus:top-4",
+        // Styling
+        "rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground",
+        "shadow-lg ring-2 ring-primary ring-offset-2 transition-all duration-150",
+        "focus:outline-none",
+      ].join(" ")}
+    >
+      Skip to main content
+    </a>
+  );
+}


### PR DESCRIPTION
Closes #296
Closes #297
Closes #307
Closes #308

## Summary

- Added `<SkipNav />` component as the first focusable element in `<body>` so keyboard users can bypass repeated navigation (WCAG 2.4.1)
- Rewrote `page.tsx` with proper semantic landmarks: `<header role="banner">`, `<main id="main-content">`, `<section aria-labelledby>`, `<footer role="contentinfo">`
- Added `aria-hidden="true"` to all decorative Lucide icons in `page.tsx` and `home-nav.tsx`
- Added `aria-label="Main navigation"` to `<nav>` in `home-nav.tsx`
- Applied `role="list"` / `role="listitem"` and `aria-label` to popular route links for clear screen-reader context
- All changes target WCAG 2.1 AA criteria: 1.3.1 Info and Relationships, 2.4.1 Bypass Blocks, 4.1.2 Name, Role, Value