### PR TITLE
fix: scope mounted auth validators to matching routes

### DIFF
--- a/packages/backend/src/middleware/validationMiddleware.ts
+++ b/packages/backend/src/middleware/validationMiddleware.ts
@@ -18,6 +18,11 @@ const schemaMap: Record<string, z.ZodTypeAny> = {
 
 export const validateRequest = (path: string) => {
   return (req: Request, res: Response, next: NextFunction) => {
+    const requestPath = (req.originalUrl || `${req.baseUrl}${req.path}`).split('?')[0];
+    if (requestPath !== path) {
+      return next();
+    }
+
     const schema = schemaMap[path];
     
     if (!schema) {
@@ -28,7 +33,7 @@ export const validateRequest = (path: string) => {
     try {
       // Validate request body
       if (req.body && Object.keys(req.body).length > 0) {
-        schema.parse(req.body);
+        req.body = schema.parse(req.body);
       }
       
       // For GET requests, validate query parameters if needed

--- a/packages/backend/tests/auth/auth.validation.mount.integration.test.ts
+++ b/packages/backend/tests/auth/auth.validation.mount.integration.test.ts
@@ -1,0 +1,56 @@
+import express from 'express';
+import request from 'supertest';
+import { authRoutes } from '../../src/api/routes/auth';
+import { validateRequest } from '../../src/middleware/validationMiddleware';
+import { AuthService } from '../../src/services/authService';
+
+jest.mock('../../src/services/authService');
+
+describe('Mounted auth validation', () => {
+  let app: express.Application;
+
+  const validWalletAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB';
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use(
+      '/api/v1/auth',
+      validateRequest('/api/v1/auth/challenge'),
+      validateRequest('/api/v1/auth/verify'),
+      validateRequest('/api/v1/auth/refresh'),
+      authRoutes,
+    );
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('validates only the matching auth route schema', async () => {
+    const mockChallenge = {
+      nonce: 'abc123def456',
+      expiresIn: 300,
+      message: 'Sign this message to authenticate with Traqora: abc123def456',
+    };
+
+    (AuthService.prototype.generateChallenge as jest.Mock).mockResolvedValue(mockChallenge);
+
+    const response = await request(app)
+      .post('/api/v1/auth/challenge')
+      .send({ walletAddress: validWalletAddress });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockChallenge);
+    expect(AuthService.prototype.generateChallenge).toHaveBeenCalledWith(validWalletAddress);
+  });
+
+  it('rejects an invalid challenge payload on the mounted route', async () => {
+    const response = await request(app)
+      .post('/api/v1/auth/challenge')
+      .send({ walletAddress: 'INVALID' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error.code).toBe('VALIDATION_ERROR');
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes a route-scoping bug in the mounted auth validation flow so each auth endpoint is validated only against its own schema.

## Issues Referenced
- Closes #227
- Closes  #285
- Closes  #304
- Closes  #298

## What Changed
- Updated the mounted request validation middleware to check the actual request path before applying a schema.
- Prevented `/api/v1/auth/challenge` requests from being incorrectly validated by the `/verify` and `/refresh` schemas.
- Preserved existing validation behavior for the intended endpoint once the path matches.
- Added a focused regression test covering the mounted auth route behavior.

## Root Cause
The auth routes were mounted with multiple `validateRequest(...)` middleware instances at the router level. Because the validator previously trusted only the configured path argument and did not verify the active request path first, sibling auth routes could be evaluated against the wrong schema.

## Impact
- Fixes false validation failures on mounted auth routes.
- Makes the auth flow more reliable without changing the route contract.
- Reduces risk for the broader input-validation/security work tracked under #221.
- Provides a safer foundation for adjacent work discussed in #208, #209, and #223.

## Validation
- Added regression coverage for mounted auth validation behavior.
- Confirmed the branch is clean, committed, and pushed.
- Local Jest execution is currently blocked in this checkout because the `jest` binary is not installed in the environment.

## Notes
This PR directly addresses the auth-validation bug within #221.
It references #208, #209, and #223 for backlog traceability, but it does not claim to implement the full scope of those issues.