### PR TITLE
feat: rate limit metrics dashboard, multi-city search route, profile customization, per-service health checks

### DIFF
--- a/packages/backend/src/api/routes/flights.ts
+++ b/packages/backend/src/api/routes/flights.ts
@@ -7,6 +7,11 @@ import { FlightSearchService } from "../../services/flightSearchService";
 import { CurrencyService } from "../../services/currencyService";
 import { FareRulesService, FareClass } from "../../services/fareRulesService";
 import { BadRequestError } from "../../utils/errors";
+import {
+  FlexibleSearchService,
+  MAX_SEGMENTS,
+  createFlexibleSearchService,
+} from "../../services/multi-city-search";
 
 const searchQuerySchema = z
   .object({
@@ -65,9 +70,27 @@ const convertSchema = z.object({
   to: z.string().length(3),
 });
 
+const segmentSchema = z.object({
+  origin: z.string().length(3),
+  destination: z.string().length(3),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  passengers: z.coerce.number().int().min(1).max(9),
+  travelClass: z
+    .enum(["economy", "premium_economy", "business", "first"])
+    .optional(),
+});
+
+const multiCitySchema = z.object({
+  segments: z.array(segmentSchema).min(2).max(MAX_SEGMENTS),
+  passengers: z.coerce.number().int().min(1).max(9),
+  sortBy: z.enum(["total_price", "total_duration"]).optional(),
+  sortOrder: z.enum(["asc", "desc"]).optional(),
+});
+
 export const createFlightRoutes = (
   flightSearchService: FlightSearchService,
   searchRateLimitMiddleware?: any,
+  flexibleSearchService: FlexibleSearchService = createFlexibleSearchService(flightSearchService),
 ) => {
   const router = Router();
   const currencyService = CurrencyService.getInstance();
@@ -143,6 +166,37 @@ export const createFlightRoutes = (
       throw new BadRequestError(error.message || "Invalid request");
     }
   }));
+
+  router.post(
+    "/multi-city",
+    asyncHandler(async (req: Request, res: Response) => {
+      const parsed = multiCitySchema.safeParse(req.body);
+      if (!parsed.success) {
+        throw new BadRequestError("Invalid multi-city search parameters", parsed.error.flatten());
+      }
+
+      const { segments, passengers, sortBy, sortOrder } = parsed.data;
+
+      try {
+        const itinerary = await flexibleSearchService.searchMultiCity({
+          segments: segments.map((s) => ({
+            origin: s.origin.toUpperCase(),
+            destination: s.destination.toUpperCase(),
+            date: s.date,
+            passengers: s.passengers,
+            travelClass: s.travelClass,
+          })),
+          passengers,
+          sortBy,
+          sortOrder,
+        });
+
+        return res.status(200).json({ success: true, data: itinerary });
+      } catch (error: any) {
+        throw new BadRequestError(error.message || "Invalid multi-city request");
+      }
+    }),
+  );
 
   router.get(
     "/price-trend",

--- a/packages/backend/src/api/routes/security.ts
+++ b/packages/backend/src/api/routes/security.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { config } from '../../config';
 import { abuseListManager } from '../../utils/rateLimiter';
+import { getRateLimitSnapshot } from '../../services/metrics';
 
 const router = Router();
 
@@ -104,6 +105,34 @@ router.get('/rate-limits/status/:ip', async (req, res) => {
       blocked: blockedStatus.blocked,
       blockMsRemaining: blockedStatus.msRemaining,
       violations,
+    },
+  });
+});
+
+/**
+ * Throttling monitoring dashboard (issue #371).
+ *
+ * Returns per-endpoint, per-tier allow/block counts since process start.
+ * Prometheus scraping (`/metrics`) remains the source of truth for
+ * alerting; this endpoint gives the admin dashboard a structured summary
+ * without parsing the exposition format.
+ */
+router.get('/rate-limits/metrics', async (_req, res) => {
+  const snapshot = getRateLimitSnapshot();
+  const totals = snapshot.reduce(
+    (acc, entry) => {
+      acc.allowed += entry.allowed;
+      acc.blocked += entry.blocked;
+      return acc;
+    },
+    { allowed: 0, blocked: 0 },
+  );
+
+  return res.json({
+    success: true,
+    data: {
+      totals,
+      byEndpoint: snapshot,
     },
   });
 });

--- a/packages/backend/src/api/routes/users.ts
+++ b/packages/backend/src/api/routes/users.ts
@@ -5,8 +5,9 @@ import { AppDataSource } from '../../db/dataSource';
 import { User } from '../../db/entities/User';
 import { Passenger } from '../../db/entities/Passenger';
 import { UserPreference } from '../../db/entities/UserPreference';
+import { UserProfile } from '../../db/entities/UserProfile';
 import { BadRequestError, NotFoundError } from '../../utils/errors';
-import { passengerSchema, userPreferencesSchema } from '../schemas';
+import { passengerSchema, userPreferencesSchema, userProfileSchema } from '../schemas';
 
 const router = Router();
 
@@ -87,6 +88,58 @@ router.put(
 
     await preferenceRepo.save(preferences);
     return res.json({ success: true, data: preferences });
+  }),
+);
+
+router.get(
+  '/profile',
+  requireAuth,
+  asyncHandler(async (req: Request, res: Response) => {
+    const walletAddress = ensureAuthenticatedUser(req);
+    const profileRepo = AppDataSource.getRepository(UserProfile);
+    const profile = await profileRepo.findOne({ where: { userId: walletAddress } });
+
+    return res.json({
+      success: true,
+      data: profile ?? {
+        userId: walletAddress,
+        displayName: null,
+        bio: null,
+        avatarUrl: null,
+        travelPreferences: null,
+      },
+    });
+  }),
+);
+
+router.patch(
+  '/profile',
+  requireAuth,
+  asyncHandler(async (req: Request, res: Response) => {
+    const walletAddress = ensureAuthenticatedUser(req);
+    const parsed = userProfileSchema.safeParse(req.body);
+    if (!parsed.success) {
+      throw new BadRequestError('Validation error', parsed.error.flatten());
+    }
+
+    const profileRepo = AppDataSource.getRepository(UserProfile);
+    let profile = await profileRepo.findOne({ where: { userId: walletAddress } });
+
+    if (!profile) {
+      profile = profileRepo.create({
+        userId: walletAddress,
+        displayName: null,
+        bio: null,
+        avatarUrl: null,
+        travelPreferences: null,
+        ...parsed.data,
+      });
+    } else {
+      Object.assign(profile, parsed.data);
+    }
+
+    await profileRepo.save(profile);
+    return res.json({ success: true, data: profile });
   }),
 );
 

--- a/packages/backend/src/api/schemas/index.ts
+++ b/packages/backend/src/api/schemas/index.ts
@@ -62,6 +62,25 @@ export const userPreferencesSchema = z.object({
   pushEnabled: z.boolean(),
 });
 
+export const travelPreferencesSchema = z.object({
+  seatPreference: z.enum(['aisle', 'window', 'middle']).optional(),
+  mealPreference: z.string().max(100).optional(),
+  preferredCabinClass: z.enum(['economy', 'premium_economy', 'business', 'first']).optional(),
+  frequentFlyerNumbers: z.record(z.string(), z.string()).optional(),
+});
+
+export const userProfileSchema = z
+  .object({
+    displayName: z.string().trim().min(1).max(80).nullable(),
+    bio: z.string().trim().max(500).nullable(),
+    avatarUrl: z.string().trim().url().max(2048).nullable(),
+    travelPreferences: travelPreferencesSchema.nullable(),
+  })
+  .partial()
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field must be provided',
+  });
+
 export const createAirlineSchema = z.object({
   airlineCode: z.string().min(2).max(10),
   airlineName: z.string().min(1),

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -27,6 +27,9 @@ import contractEventRoutes from './api/routes/contract-events';
 import transactionRoutes from './api/routes/transactions';
 import checkinRoutes from './api/routes/checkin';
 import { documentRoutes } from './api/routes/documents';
+import { alertRoutes } from './api/routes/alerts';
+import { reviewRoutes } from './api/routes/reviews';
+import { userRoutes } from './api/routes/users';
 import { carbonRoutes } from './api/routes/carbon';
 import { createCurrencyRoutes } from './api/routes/currencies';
 // @ts-ignore
@@ -193,6 +196,7 @@ export const createApp = async (options: AppOptions = {}) => {
   app.use('/api/v1/group-bookings', requireAuth, groupBookingRoutes); // <-- Added group booking routes
   app.use('/api/v1/security', securityRoutes);
   app.use('/api/v1/documents', requireAuth, documentRoutes);
+  app.use('/api/v1/users', userRoutes);
 
   // Admin routes
   app.use('/api/v1/admin/auth', adminAuthRoutes);

--- a/packages/backend/src/db/dataSource.ts
+++ b/packages/backend/src/db/dataSource.ts
@@ -22,6 +22,7 @@ import { InsurancePolicy } from "./entities/InsurancePolicy";
 import { InsuranceClaim } from "./entities/InsuranceClaim";
 import { CheckIn } from "./entities/CheckIn";
 import { BiometricCredential } from "./entities/BiometricCredential";
+import { UserProfile } from "./entities/UserProfile";
 
 const isTest = process.env.NODE_ENV === "test";
 
@@ -53,6 +54,7 @@ export const AppDataSource = new DataSource(
         InsuranceClaim,
         CheckIn,
         BiometricCredential,
+        UserProfile,
       ],
       logging: false,
     }
@@ -82,6 +84,7 @@ export const AppDataSource = new DataSource(
         InsuranceClaim,
         CheckIn,
         BiometricCredential,
+        UserProfile,
       ],
       migrations: [__dirname + "/migrations/*.{js,ts}"],
       ssl:

--- a/packages/backend/src/db/entities/BiometricCredential.ts
+++ b/packages/backend/src/db/entities/BiometricCredential.ts
@@ -25,10 +25,10 @@ export class BiometricCredential {
   @Column({ default: 0 })
   counter: number;
 
-  @Column({ default: "fingerprint" })
+  @Column({ type: "varchar", default: "fingerprint" })
   credentialType: "fingerprint" | "face";
 
-  @Column({ nullable: true })
+  @Column({ type: "varchar", nullable: true })
   deviceName: string | null;
 
   @Column({ type: "text", nullable: true })
@@ -43,6 +43,6 @@ export class BiometricCredential {
   @UpdateDateColumn()
   updatedAt: Date;
 
-  @Column({ type: "timestamp", nullable: true })
+  @Column({ type: process.env.NODE_ENV === "test" ? "datetime" : "timestamp", nullable: true })
   lastUsedAt: Date | null;
 }

--- a/packages/backend/src/db/entities/ContractEventLog.ts
+++ b/packages/backend/src/db/entities/ContractEventLog.ts
@@ -23,10 +23,10 @@ export class ContractEventLog {
   @Column({ type: 'int' })
   ledger: number;
 
-  @Column({ name: 'wallet_address', nullable: true })
+  @Column({ type: 'varchar', name: 'wallet_address', nullable: true })
   walletAddress: string | null;
 
-  @Column({ type: 'jsonb', default: '{}' })
+  @Column({ type: process.env.NODE_ENV === 'test' ? 'simple-json' : 'jsonb', default: '{}' })
   data: Record<string, unknown>;
 
   @CreateDateColumn({ name: 'indexed_at' })

--- a/packages/backend/src/db/entities/GroupMember.ts
+++ b/packages/backend/src/db/entities/GroupMember.ts
@@ -55,10 +55,10 @@ export class GroupMember {
   @Column({ type: 'boolean', default: false })
   isInvited!: boolean;
 
-  @Column({ type: 'timestamp', nullable: true })
+  @Column({ type: process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamp', nullable: true })
   invitedAt?: Date | null;
 
-  @Column({ type: 'timestamp', nullable: true })
+  @Column({ type: process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamp', nullable: true })
   confirmedAt?: Date | null;
 
   @Column({ type: 'text', nullable: true })

--- a/packages/backend/src/db/entities/UserProfile.ts
+++ b/packages/backend/src/db/entities/UserProfile.ts
@@ -1,0 +1,54 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from "typeorm";
+
+export interface TravelPreferences {
+  seatPreference?: "aisle" | "window" | "middle";
+  mealPreference?: string;
+  preferredCabinClass?: "economy" | "premium_economy" | "business" | "first";
+  frequentFlyerNumbers?: Record<string, string>;
+}
+
+/**
+ * Creator/user-facing profile customization (issue #374): avatar, display
+ * name, bio, and travel preferences. Distinct from `UserPreference`, which
+ * holds notification channel settings.
+ *
+ * `avatarUrl` stores a URL only — there is no image upload/processing
+ * pipeline or CDN integration here (out of scope; see PR description).
+ */
+@Entity("user_profiles")
+export class UserProfile {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Index({ unique: true })
+  @Column()
+  userId: string; // walletAddress, matching UserPreference's convention
+
+  @Column({ type: "varchar", length: 80, nullable: true })
+  displayName: string | null;
+
+  @Column({ type: "varchar", length: 500, nullable: true })
+  bio: string | null;
+
+  @Column({ type: "varchar", length: 2048, nullable: true })
+  avatarUrl: string | null;
+
+  @Column({
+    type: process.env.NODE_ENV === "test" ? "simple-json" : "jsonb",
+    nullable: true,
+  })
+  travelPreferences: TravelPreferences | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/packages/backend/src/db/migrations/1756000000000-CreateUserProfiles.ts
+++ b/packages/backend/src/db/migrations/1756000000000-CreateUserProfiles.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateUserProfiles1756000000000 implements MigrationInterface {
+  name = 'CreateUserProfiles1756000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "user_profiles" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        "userId" varchar NOT NULL,
+        "displayName" varchar(80),
+        "bio" varchar(500),
+        "avatarUrl" varchar(2048),
+        "travelPreferences" jsonb,
+        "createdAt" timestamptz NOT NULL DEFAULT now(),
+        "updatedAt" timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+    await queryRunner.query(`CREATE UNIQUE INDEX IF NOT EXISTS "idx_user_profiles_userId" ON "user_profiles" ("userId")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_user_profiles_userId"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "user_profiles"`);
+  }
+}

--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -1,8 +1,60 @@
 import { Router } from 'express';
+import Redis from 'ioredis';
+import { Horizon } from '@stellar/stellar-sdk';
 import { AppDataSource } from '../db/dataSource';
 import { performanceMonitor } from '../monitoring/performance';
+import { getConfig } from '../config';
+import { updateSystemHealth, updateUptimeMetric, uptimeSeconds } from '../services/metrics';
+import { logger } from '../utils/logger';
 
 const router = Router();
+
+const CHECK_TIMEOUT_MS = 3000;
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: NodeJS.Timeout;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer!);
+  }
+}
+
+async function checkDatabase(): Promise<{ healthy: boolean; error?: string }> {
+  try {
+    if (!AppDataSource.isInitialized) return { healthy: false, error: 'not initialized' };
+    await withTimeout(AppDataSource.query('SELECT 1'), CHECK_TIMEOUT_MS);
+    return { healthy: true };
+  } catch (error) {
+    return { healthy: false, error: (error as Error).message };
+  }
+}
+
+async function checkRedis(redisUrl: string): Promise<{ healthy: boolean; error?: string }> {
+  const client = new Redis(redisUrl, { lazyConnect: true, maxRetriesPerRequest: 1 });
+  try {
+    await withTimeout(client.connect(), CHECK_TIMEOUT_MS);
+    await withTimeout(client.ping(), CHECK_TIMEOUT_MS);
+    return { healthy: true };
+  } catch (error) {
+    return { healthy: false, error: (error as Error).message };
+  } finally {
+    client.disconnect();
+  }
+}
+
+async function checkStellar(horizonUrl: string): Promise<{ healthy: boolean; error?: string }> {
+  try {
+    const server = new Horizon.Server(horizonUrl);
+    await withTimeout(server.ledgers().limit(1).call(), CHECK_TIMEOUT_MS);
+    return { healthy: true };
+  } catch (error) {
+    return { healthy: false, error: (error as Error).message };
+  }
+}
 
 router.get('/', async (_req, res) => {
   const db = AppDataSource.isInitialized ? 'ok' : 'unavailable';
@@ -15,6 +67,49 @@ router.get('/performance', async (_req, res) => {
   const status = snapshot.status === 'critical' ? 503 : 200;
 
   res.status(status).json(snapshot);
+});
+
+/**
+ * Per-service health check (issue #375). Unlike the boot-time-only checks
+ * in utils/health-check.ts, this runs on demand so an admin dashboard or
+ * uptime monitor can poll live status for each dependency independently.
+ * Skips real network calls in the test environment, matching the
+ * convention in utils/health-check.ts.
+ */
+router.get('/services', async (_req, res) => {
+  const config = getConfig();
+
+  const [database, redis, stellar] =
+    process.env.NODE_ENV === 'test'
+      ? [{ healthy: true }, { healthy: true }, { healthy: true }]
+      : await Promise.all([
+          checkDatabase(),
+          checkRedis(config.redisUrl),
+          checkStellar(config.horizonUrl),
+        ]);
+
+  updateSystemHealth('database', database.healthy);
+  updateSystemHealth('redis', redis.healthy);
+  updateSystemHealth('stellar', stellar.healthy);
+  updateUptimeMetric();
+
+  const services = { database, redis, stellar };
+  const allHealthy = Object.values(services).every((s) => s.healthy);
+  const anyHealthy = Object.values(services).some((s) => s.healthy);
+  const overall = allHealthy ? 'operational' : anyHealthy ? 'degraded' : 'down';
+
+  for (const [name, result] of Object.entries(services)) {
+    if (!result.healthy) {
+      logger.warn('Health check failed for service', { service: name, error: result.error });
+    }
+  }
+
+  res.status(allHealthy ? 200 : 503).json({
+    overall,
+    uptimeSeconds: (await uptimeSeconds.get()).values[0]?.value ?? 0,
+    services,
+    checkedAt: new Date().toISOString(),
+  });
 });
 
 export default router;

--- a/packages/backend/src/services/metrics.ts
+++ b/packages/backend/src/services/metrics.ts
@@ -293,6 +293,17 @@ export const uptimeSeconds = new Gauge({
 });
 
 // ============================================================================
+// Rate Limiting Metrics (issue #371)
+// ============================================================================
+
+export const rateLimitDecisions = new Counter({
+  name: 'traqora_rate_limit_decisions_total',
+  help: 'Total number of rate limit decisions, labeled by outcome',
+  labelNames: ['endpoint', 'tier', 'outcome'],
+  registers: [register],
+});
+
+// ============================================================================
 // Helper Functions
 // ============================================================================
 
@@ -418,6 +429,54 @@ export const recordCacheOperation = (
   cacheOperationsTotal.inc(labels);
   cacheOperationDuration.observe(labels, durationSeconds);
   performanceMonitor.recordCache(cache, result, durationSeconds);
+};
+
+/**
+ * In-memory snapshot of rate-limit decisions, keyed by `${endpoint}:${tier}`.
+ * The Prometheus counter above is the source of truth for scraping/alerting;
+ * this snapshot exists so the admin dashboard (issue #371) can return a
+ * structured JSON summary without parsing Prometheus text exposition format.
+ */
+interface RateLimitSnapshotEntry {
+  endpoint: string;
+  tier: string;
+  allowed: number;
+  blocked: number;
+  lastBlockedAt: string | null;
+}
+
+const rateLimitSnapshots = new Map<string, RateLimitSnapshotEntry>();
+
+export const recordRateLimitDecision = (
+  endpoint: string,
+  tier: string,
+  outcome: 'allowed' | 'blocked'
+) => {
+  rateLimitDecisions.inc({ endpoint, tier, outcome });
+
+  const key = `${endpoint}:${tier}`;
+  const entry = rateLimitSnapshots.get(key) ?? {
+    endpoint,
+    tier,
+    allowed: 0,
+    blocked: 0,
+    lastBlockedAt: null,
+  };
+  if (outcome === 'allowed') {
+    entry.allowed += 1;
+  } else {
+    entry.blocked += 1;
+    entry.lastBlockedAt = new Date().toISOString();
+  }
+  rateLimitSnapshots.set(key, entry);
+};
+
+export const getRateLimitSnapshot = (): RateLimitSnapshotEntry[] =>
+  Array.from(rateLimitSnapshots.values());
+
+/** Test hook: reset the in-memory snapshot between test cases. */
+export const __resetRateLimitSnapshot = () => {
+  rateLimitSnapshots.clear();
 };
 
 // Update uptime every 10 seconds

--- a/packages/backend/src/utils/rateLimiter.ts
+++ b/packages/backend/src/utils/rateLimiter.ts
@@ -7,6 +7,7 @@ import {
   RateLimiterRes,
 } from 'rate-limiter-flexible';
 import { logger } from './logger';
+import { recordRateLimitDecision } from '../services/metrics';
 
 export interface IpRateLimitOptions {
   points: number;
@@ -546,6 +547,7 @@ export const createTieredRateLimiter = (options: TieredRateLimitOptions) => {
       const retryAfter = Math.max(1, Math.ceil(blockedStatus.msRemaining / 1000));
       setThrottledHeaders(res, options.public.points, retryAfter);
       res.setHeader('X-Captcha-Required', 'true');
+      recordRateLimitDecision(path, tier, 'blocked');
       return res.status(429).json({
         error: {
           code: 'IP_BLOCKED',
@@ -567,6 +569,7 @@ export const createTieredRateLimiter = (options: TieredRateLimitOptions) => {
       });
       setThrottledHeaders(res, options.ddos.points, Math.ceil(options.blockDurationSeconds));
       res.setHeader('X-Captcha-Required', 'true');
+      recordRateLimitDecision(path, tier, 'blocked');
       return res.status(429).json({
         error: {
           code: 'DDOS_PROTECTION_TRIGGERED',
@@ -582,6 +585,7 @@ export const createTieredRateLimiter = (options: TieredRateLimitOptions) => {
     try {
       const result = await limiter.consume(`${keyIdentity}:${path}`);
       setRateLimitHeaders(res, limit, result);
+      recordRateLimitDecision(path, tier, 'allowed');
       return next();
     } catch (tierError: any) {
       const violations = await abuseStore.incrementViolation(ip, 3600);
@@ -604,6 +608,7 @@ export const createTieredRateLimiter = (options: TieredRateLimitOptions) => {
         blocked: violations >= options.blockAfterViolations,
       });
 
+      recordRateLimitDecision(path, tier, 'blocked');
       return res.status(429).json({
         error: {
           code: 'RATE_LIMIT_EXCEEDED',

--- a/packages/backend/tests/integration/rate-limit-dashboard.integration.test.ts
+++ b/packages/backend/tests/integration/rate-limit-dashboard.integration.test.ts
@@ -1,0 +1,83 @@
+import request from 'supertest';
+import { createApp } from '../../src/app';
+import { __resetRateLimitSnapshot } from '../../src/services/metrics';
+
+const ADMIN_KEY = { 'X-Admin-Api-Key': 'dev-admin-key' };
+
+const createRateLimitedApp = () =>
+  createApp({
+    globalRateLimit: false,
+    tieredRateLimit: {
+      redisUrl: undefined,
+      public: { points: 2, durationSeconds: 60 },
+      user: { points: 4, durationSeconds: 60 },
+      premium: { points: 6, durationSeconds: 60 },
+      ddos: { points: 100, durationSeconds: 60 },
+      blockDurationSeconds: 120,
+      blockAfterViolations: 10,
+      captchaAfterViolations: 10,
+    },
+  });
+
+describe('rate limit throttling dashboard (issue #371)', () => {
+  beforeEach(() => {
+    __resetRateLimitSnapshot();
+  });
+
+  it('rejects requests to the metrics endpoint without an admin key', async () => {
+    const app = await createRateLimitedApp();
+
+    const res = await request(app).get('/api/v1/security/rate-limits/metrics');
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('counts its own request when queried with no prior traffic', async () => {
+    // The dashboard endpoint is itself behind the tiered limiter, so reading
+    // it is traffic too — this asserts that self-consistency rather than an
+    // artificial "nothing happened yet" state.
+    const app = await createRateLimitedApp();
+
+    const res = await request(app)
+      .get('/api/v1/security/rate-limits/metrics')
+      .set(ADMIN_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.totals).toEqual({ allowed: 1, blocked: 0 });
+  });
+
+  it('reflects allowed and blocked requests after traffic against the public tier', async () => {
+    const app = await createRateLimitedApp();
+    const ip = '203.0.113.77';
+
+    // public tier limit is 2/min: first two allowed, third blocked.
+    // /api/v1/security/rate-limits/lists is admin-gated but still passes
+    // through the app-level tiered limiter before that check runs.
+    await request(app)
+      .get('/api/v1/security/rate-limits/lists')
+      .set('x-forwarded-for', ip);
+    await request(app)
+      .get('/api/v1/security/rate-limits/lists')
+      .set('x-forwarded-for', ip);
+    await request(app)
+      .get('/api/v1/security/rate-limits/lists')
+      .set('x-forwarded-for', ip);
+
+    const res = await request(app)
+      .get('/api/v1/security/rate-limits/metrics')
+      .set(ADMIN_KEY)
+      .set('x-forwarded-for', ip);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.totals.allowed).toBeGreaterThanOrEqual(2);
+    expect(res.body.data.totals.blocked).toBeGreaterThanOrEqual(1);
+
+    const publicEntry = res.body.data.byEndpoint.find(
+      (e: { tier: string }) => e.tier === 'public'
+    );
+    expect(publicEntry).toBeDefined();
+    expect(publicEntry.blocked).toBeGreaterThanOrEqual(1);
+    expect(publicEntry.lastBlockedAt).toEqual(expect.any(String));
+  });
+});

--- a/packages/backend/tests/integration/user-profile.integration.test.ts
+++ b/packages/backend/tests/integration/user-profile.integration.test.ts
@@ -1,0 +1,128 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { createApp } from '../../src/app';
+import { AppDataSource, initDataSource } from '../../src/db/dataSource';
+import { config } from '../../src/config';
+
+const WALLET = 'GABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZA';
+const OTHER_WALLET = 'GZYXWVUTSRQPONMLKJIHGFEDCBAZYXWVUTSRQPONMLKJIHGFEDCBA';
+
+const token = jwt.sign({ walletAddress: WALLET, walletType: 'freighter' }, config.jwtSecret, {
+  expiresIn: '1h',
+});
+const otherToken = jwt.sign(
+  { walletAddress: OTHER_WALLET, walletType: 'freighter' },
+  config.jwtSecret,
+  { expiresIn: '1h' },
+);
+
+describe('user profile customization (issue #374)', () => {
+  let app: import('express').Express;
+
+  beforeAll(async () => {
+    await initDataSource();
+    app = await createApp({ globalRateLimit: false, tieredRateLimit: false });
+  });
+
+  afterAll(async () => {
+    if (AppDataSource.isInitialized) await AppDataSource.destroy();
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const res = await request(app).get('/api/v1/users/profile');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns an empty default profile before any update', async () => {
+    const res = await request(app)
+      .get('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      userId: WALLET,
+      displayName: null,
+      bio: null,
+      avatarUrl: null,
+      travelPreferences: null,
+    });
+  });
+
+  it('rejects an update with no fields', async () => {
+    const res = await request(app)
+      .patch('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an invalid avatarUrl', async () => {
+    const res = await request(app)
+      .patch('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ avatarUrl: 'not-a-url' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a displayName over 80 characters', async () => {
+    const res = await request(app)
+      .patch('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ displayName: 'x'.repeat(81) });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('creates a profile on first update and persists all fields', async () => {
+    const res = await request(app)
+      .patch('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        displayName: 'Ada Explorer',
+        bio: 'Loves open-jaw itineraries.',
+        avatarUrl: 'https://cdn.example.com/avatars/ada.png',
+        travelPreferences: { seatPreference: 'window', preferredCabinClass: 'business' },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toMatchObject({
+      userId: WALLET,
+      displayName: 'Ada Explorer',
+      bio: 'Loves open-jaw itineraries.',
+      avatarUrl: 'https://cdn.example.com/avatars/ada.png',
+      travelPreferences: { seatPreference: 'window', preferredCabinClass: 'business' },
+    });
+
+    const getRes = await request(app)
+      .get('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${token}`);
+    expect(getRes.body.data.displayName).toBe('Ada Explorer');
+  });
+
+  it('performs a partial update without clobbering other fields', async () => {
+    await request(app)
+      .patch('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ displayName: 'Partial User', bio: 'original bio' });
+
+    const res = await request(app)
+      .patch('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${otherToken}`)
+      .send({ bio: 'updated bio only' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.displayName).toBe('Partial User');
+    expect(res.body.data.bio).toBe('updated bio only');
+  });
+
+  it('scopes profiles per wallet', async () => {
+    const res = await request(app)
+      .get('/api/v1/users/profile')
+      .set('Authorization', `Bearer ${otherToken}`);
+
+    expect(res.body.data.userId).toBe(OTHER_WALLET);
+    expect(res.body.data.displayName).toBe('Partial User');
+  });
+});

--- a/packages/backend/tests/routes/flights.multi-city.test.ts
+++ b/packages/backend/tests/routes/flights.multi-city.test.ts
@@ -1,0 +1,151 @@
+import express from 'express';
+import request from 'supertest';
+import { createFlightRoutes } from '../../src/api/routes/flights';
+import type { FlightSearchService } from '../../src/services/flightSearchService';
+import type { FlexibleSearchService, MultiCityItinerary } from '../../src/services/multi-city-search';
+
+/**
+ * Mounts createFlightRoutes on a bare express app (no createApp(), no
+ * DB init, no unrelated middleware). The multi-city route only depends on
+ * FlexibleSearchService, so it is mocked directly.
+ */
+function buildApp(flexibleSearchService: Partial<FlexibleSearchService>) {
+  const app = express();
+  app.use(express.json());
+  app.use(
+    '/api/v1/flights',
+    createFlightRoutes(
+      {} as FlightSearchService,
+      undefined,
+      flexibleSearchService as FlexibleSearchService,
+    ),
+  );
+  // Minimal error handler mirroring the shape asyncHandler-wrapped errors expect
+  app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(err.statusCode || 400).json({ error: err.message, details: err.details });
+  });
+  return app;
+}
+
+const sampleItinerary: MultiCityItinerary = {
+  segments: [],
+  totalPrice: 450,
+  totalDuration: 900,
+  isOpenJaw: true,
+  baggageAllowance: { checkIn: 23, carryOn: 10, currency: 'kg', note: 'test' },
+};
+
+describe('POST /api/v1/flights/multi-city (issue #372)', () => {
+  it('returns 400 when fewer than 2 segments are provided', async () => {
+    const searchMultiCity = jest.fn();
+    const app = buildApp({ searchMultiCity });
+
+    const res = await request(app)
+      .post('/api/v1/flights/multi-city')
+      .send({
+        segments: [{ origin: 'JFK', destination: 'LHR', date: '2026-08-01', passengers: 1 }],
+        passengers: 1,
+      });
+
+    expect(res.status).toBe(400);
+    expect(searchMultiCity).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when more than MAX_SEGMENTS segments are provided', async () => {
+    const searchMultiCity = jest.fn();
+    const app = buildApp({ searchMultiCity });
+
+    const segment = { origin: 'JFK', destination: 'LHR', date: '2026-08-01', passengers: 1 };
+    const res = await request(app)
+      .post('/api/v1/flights/multi-city')
+      .send({ segments: Array(6).fill(segment), passengers: 1 });
+
+    expect(res.status).toBe(400);
+    expect(searchMultiCity).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a malformed segment (bad date, wrong airport code length)', async () => {
+    const searchMultiCity = jest.fn();
+    const app = buildApp({ searchMultiCity });
+
+    const res = await request(app)
+      .post('/api/v1/flights/multi-city')
+      .send({
+        segments: [
+          { origin: 'JFK', destination: 'LHR', date: '2026-08-01', passengers: 1 },
+          { origin: 'LHR', destination: 'CDGX', date: 'not-a-date', passengers: 1 },
+        ],
+        passengers: 1,
+      });
+
+    expect(res.status).toBe(400);
+    expect(searchMultiCity).not.toHaveBeenCalled();
+  });
+
+  it('uppercases airport codes and forwards segments to the service', async () => {
+    const searchMultiCity = jest.fn().mockResolvedValue(sampleItinerary);
+    const app = buildApp({ searchMultiCity });
+
+    const res = await request(app)
+      .post('/api/v1/flights/multi-city')
+      .send({
+        segments: [
+          { origin: 'jfk', destination: 'lhr', date: '2026-08-01', passengers: 2 },
+          { origin: 'lhr', destination: 'cdg', date: '2026-08-05', passengers: 2 },
+        ],
+        passengers: 2,
+        sortBy: 'total_duration',
+        sortOrder: 'desc',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual(sampleItinerary);
+
+    expect(searchMultiCity).toHaveBeenCalledWith({
+      segments: [
+        { origin: 'JFK', destination: 'LHR', date: '2026-08-01', passengers: 2, travelClass: undefined },
+        { origin: 'LHR', destination: 'CDG', date: '2026-08-05', passengers: 2, travelClass: undefined },
+      ],
+      passengers: 2,
+      sortBy: 'total_duration',
+      sortOrder: 'desc',
+    });
+  });
+
+  it('returns the open-jaw flag from the service response', async () => {
+    const searchMultiCity = jest.fn().mockResolvedValue({ ...sampleItinerary, isOpenJaw: true });
+    const app = buildApp({ searchMultiCity });
+
+    const res = await request(app)
+      .post('/api/v1/flights/multi-city')
+      .send({
+        segments: [
+          { origin: 'JFK', destination: 'LHR', date: '2026-08-01', passengers: 1 },
+          { origin: 'CDG', destination: 'JFK', date: '2026-08-05', passengers: 1 },
+        ],
+        passengers: 1,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.isOpenJaw).toBe(true);
+  });
+
+  it('propagates service errors as 400s', async () => {
+    const searchMultiCity = jest.fn().mockRejectedValue(new Error('no flights available'));
+    const app = buildApp({ searchMultiCity });
+
+    const res = await request(app)
+      .post('/api/v1/flights/multi-city')
+      .send({
+        segments: [
+          { origin: 'JFK', destination: 'LHR', date: '2026-08-01', passengers: 1 },
+          { origin: 'LHR', destination: 'CDG', date: '2026-08-05', passengers: 1 },
+        ],
+        passengers: 1,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('no flights available');
+  });
+});

--- a/packages/backend/tests/routes/health-services.test.ts
+++ b/packages/backend/tests/routes/health-services.test.ts
@@ -1,0 +1,52 @@
+import express from 'express';
+import request from 'supertest';
+
+describe('GET /health/services (issue #375)', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it('reports operational status for all services in the test environment', async () => {
+    // Fresh module registry per test file avoids leaking prom-client
+    // registrations across other suites sharing the same jest worker.
+    jest.resetModules();
+    const healthRouter = require('../../src/routes/health').default;
+
+    const app = express();
+    app.use('/health', healthRouter);
+
+    const res = await request(app).get('/health/services');
+
+    expect(res.status).toBe(200);
+    expect(res.body.overall).toBe('operational');
+    expect(res.body.services).toEqual({
+      database: { healthy: true },
+      redis: { healthy: true },
+      stellar: { healthy: true },
+    });
+    expect(typeof res.body.uptimeSeconds).toBe('number');
+    expect(res.body.checkedAt).toEqual(expect.any(String));
+  });
+
+  it('is a proper route mounted alongside the existing root and performance endpoints', async () => {
+    jest.resetModules();
+    const healthRouter = require('../../src/routes/health').default;
+
+    const app = express();
+    app.use('/health', healthRouter);
+
+    const rootRes = await request(app).get('/health');
+    const perfRes = await request(app).get('/health/performance');
+    const servicesRes = await request(app).get('/health/services');
+
+    expect(rootRes.status).toBeGreaterThanOrEqual(200);
+    expect(perfRes.status).toBeGreaterThanOrEqual(200);
+    expect(servicesRes.status).toBe(200);
+  });
+});

--- a/packages/backend/tests/services/rate-limit-metrics.test.ts
+++ b/packages/backend/tests/services/rate-limit-metrics.test.ts
@@ -1,0 +1,82 @@
+import {
+  recordRateLimitDecision,
+  getRateLimitSnapshot,
+  rateLimitDecisions,
+  register,
+  __resetRateLimitSnapshot,
+} from '../../src/services/metrics';
+
+describe('rate limit metrics (issue #371)', () => {
+  beforeEach(() => {
+    __resetRateLimitSnapshot();
+  });
+
+  it('starts with an empty snapshot', () => {
+    expect(getRateLimitSnapshot()).toEqual([]);
+  });
+
+  it('records an allowed decision', () => {
+    recordRateLimitDecision('/api/v1/flights/search', 'public', 'allowed');
+
+    const snapshot = getRateLimitSnapshot();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0]).toMatchObject({
+      endpoint: '/api/v1/flights/search',
+      tier: 'public',
+      allowed: 1,
+      blocked: 0,
+      lastBlockedAt: null,
+    });
+  });
+
+  it('records a blocked decision and sets lastBlockedAt', () => {
+    recordRateLimitDecision('/api/v1/bookings', 'user', 'blocked');
+
+    const snapshot = getRateLimitSnapshot();
+    expect(snapshot).toHaveLength(1);
+    expect(snapshot[0].blocked).toBe(1);
+    expect(snapshot[0].allowed).toBe(0);
+    expect(snapshot[0].lastBlockedAt).toEqual(expect.any(String));
+    expect(new Date(snapshot[0].lastBlockedAt!).toString()).not.toBe('Invalid Date');
+  });
+
+  it('accumulates counts per endpoint+tier key without cross-contamination', () => {
+    recordRateLimitDecision('/api/v1/flights/search', 'public', 'allowed');
+    recordRateLimitDecision('/api/v1/flights/search', 'public', 'allowed');
+    recordRateLimitDecision('/api/v1/flights/search', 'public', 'blocked');
+    recordRateLimitDecision('/api/v1/flights/search', 'premium', 'allowed');
+    recordRateLimitDecision('/api/v1/bookings', 'public', 'blocked');
+
+    const snapshot = getRateLimitSnapshot();
+    expect(snapshot).toHaveLength(3);
+
+    const searchPublic = snapshot.find(
+      (e) => e.endpoint === '/api/v1/flights/search' && e.tier === 'public'
+    );
+    expect(searchPublic).toMatchObject({ allowed: 2, blocked: 1 });
+
+    const searchPremium = snapshot.find(
+      (e) => e.endpoint === '/api/v1/flights/search' && e.tier === 'premium'
+    );
+    expect(searchPremium).toMatchObject({ allowed: 1, blocked: 0 });
+
+    const bookingsPublic = snapshot.find((e) => e.endpoint === '/api/v1/bookings');
+    expect(bookingsPublic).toMatchObject({ allowed: 0, blocked: 1 });
+  });
+
+  it('increments the Prometheus counter alongside the snapshot', async () => {
+    recordRateLimitDecision('/api/v1/flights/search', 'public', 'allowed');
+    recordRateLimitDecision('/api/v1/flights/search', 'public', 'blocked');
+
+    const metricsText = await register.getSingleMetricAsString(rateLimitDecisions.name);
+    expect(metricsText).toContain('endpoint="/api/v1/flights/search"');
+    expect(metricsText).toContain('outcome="allowed"');
+    expect(metricsText).toContain('outcome="blocked"');
+  });
+
+  it('reset clears the snapshot for the next test', () => {
+    recordRateLimitDecision('/api/v1/flights/search', 'public', 'allowed');
+    __resetRateLimitSnapshot();
+    expect(getRateLimitSnapshot()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Implements four issues against the backend. Each was scoped down from its full multi-step procedure to the concrete, verifiable gap that actually existed in the codebase — several of the requested subsystems (token-bucket rate limiting, multi-city/open-jaw search logic, monitoring stack) already exist but were either unmonitored, unwired, or partially built. Descoped items are called out per issue below, along with a couple of pre-existing bugs that had to be fixed to make the new code testable at all.

closes #371
closes #372
closes #374
closes #375

## Changes

**#371 — rate limit throttling dashboard**
The repo already has a full token-bucket + tiered (public/user/premium/ddos) rate limiter with IP block/whitelist/blacklist management (`utils/rateLimiter.ts`, `api/routes/security.ts`) — the acceptance criteria's actual gap was the monitoring dashboard. Added:
- `traqora_rate_limit_decisions_total` Prometheus counter (`services/metrics.ts`), labeled by endpoint/tier/outcome, plus an in-memory snapshot (`recordRateLimitDecision`/`getRateLimitSnapshot`) so a dashboard can read structured JSON without parsing exposition format.
- Instrumented all four decision points in `createTieredRateLimiter` (IP-blocked, DDoS-triggered, tier-allowed, tier-exceeded) — this is the middleware actually mounted globally in `app.ts`, not the separate unused `rate-limit-tiers.ts` module (confirmed via `grep` that its exports have zero call sites; left untouched to avoid touching dead code).
- `GET /api/v1/security/rate-limits/metrics` admin endpoint (same `x-admin-api-key` gate as the existing rate-limit routes) returning per-endpoint/tier allow/block totals.
- Descoped: no separate `packages/client/app/admin` UI page — the JSON endpoint is the "dashboard" data source; a page can consume it later. No new alerting integration (Prometheus/Grafana/Alertmanager already exist under `monitoring/`).

**#372 — multi-city / open-jaw flight search**
`services/multi-city-search.ts` (`FlexibleSearchService`, up to 5 segments, open-jaw detection, baggage accumulation) was fully implemented but had **no API route** — `grep` confirmed zero references outside its own file. Added `POST /api/v1/flights/multi-city`, validated with zod (2–5 segments, IATA codes, dates), uppercasing airport codes and forwarding to the existing service; `createFlightRoutes` takes the service as an optional injected third argument (constructed by default) so it can be unit-tested without wiring up the DB. Descoped: no new client-side segment-builder UI (out of scope for this backend-focused batch; the existing `flexible-date-search.tsx` component is unrelated single-date logic).

**#374 — avatar and profile customization**
No profile concept existed beyond the bare `User` entity (walletAddress/walletType only) — and `api/routes/users.ts` (which already had `/me`, `/preferences`, `/passengers`) was **never mounted in `app.ts`** at all. Added:
- `UserProfile` entity + migration: `displayName`, `bio`, `avatarUrl` (URL string only — no upload/processing/CDN pipeline, noted as out of scope), `travelPreferences` (jsonb: seat/meal/cabin-class/frequent-flyer-numbers).
- `GET`/`PATCH /api/v1/users/profile`, zod-validated (partial updates, at-least-one-field, url validation on avatar, 80-char display name cap).
- Mounted `userRoutes` at `/api/v1/users` in `app.ts` (previously unmounted — every route in that file, including `/me` and `/preferences`, was unreachable before this).

**#375 — health monitoring extension**
Startup-only connectivity checks (`utils/health-check.ts`) and a full Prometheus/Grafana/Loki/Alertmanager stack (`monitoring/`) already exist — the gap was an on-demand, per-service endpoint an admin dashboard or external uptime monitor could poll. Added `GET /health/services`, checking DB/Redis/Stellar Horizon independently (3s timeout each, skips real network calls in test env matching the existing `verifyConnectivity` convention), updating the existing `systemHealth` Gauge and returning `{ overall, uptimeSeconds, services, checkedAt }`. Descoped: no incident-tracking workflow, public status page, or geographic monitoring — the existing Grafana/Alertmanager stack is the intended home for those, not a bespoke build here.

## Pre-existing bugs fixed (required to run any test at all)
- `app.ts` referenced `alertRoutes` and `reviewRoutes` without importing them — a `ReferenceError` that crashed `createApp()` for **every** consumer, including the pre-existing `rate-limiter.integration.test.ts`. Added the two missing imports.
- `ContractEventLog.walletAddress` (`string | null`, no explicit `type`), `ContractEventLog.data` (raw `jsonb`), `BiometricCredential.deviceName`/`credentialType`, and `GroupMember.invitedAt`/`confirmedAt` (raw `timestamp`) had no explicit TypeORM column type or used a Postgres-only type string — under sqlite (the test datasource) these throw `DataTypeNotSupportedError` at `initDataSource()`, 500ing **every** `/api/v1/*` route in test env. Fixed using the exact convention already established elsewhere in the codebase (`process.env.NODE_ENV === 'test' ? 'datetime'/'simple-json' : 'timestamp'/'jsonb'`, explicit `varchar`).

These are both pure additive/type-annotation fixes with no behavior change on Postgres/production; they were blocking verification of this PR's own tests, not introduced by it.

## Test plan
- 5 new test files, **25 tests, all passing**: `rate-limit-metrics.test.ts` (unit), `rate-limit-dashboard.integration.test.ts` (supertest against `createApp()`), `flights.multi-city.test.ts` (isolated router, mocked service), `user-profile.integration.test.ts` (supertest + real sqlite datasource + jwt auth, covers auth/validation/create/partial-update/per-wallet scoping), `health-services.test.ts`.
- `npx tsc --noEmit` and `npx eslint src` were run on a clean checkout of `upstream/main` for comparison: **50 pre-existing type errors and 909 pre-existing lint errors** exist repo-wide, none in files this PR touches (verified by diffing error locations against changed files/lines). This PR does not attempt to fix that backlog — flagging so it isn't mistaken for something introduced here.