### PR TITLE
test(backend): add retry logic tests

### DIFF
--- a/packages/backend/tests/services/retry.test.ts
+++ b/packages/backend/tests/services/retry.test.ts
@@ -1,0 +1,75 @@
+import { withRetries, sleep } from '../../src/services/retry';
+import { withRetry } from '../../src/services/ErrorHandlingService';
+
+jest.mock('../../src/services/ErrorHandlingService', () => ({
+  withRetry: jest.fn(),
+  sleep: jest.fn(),
+}));
+
+describe('withRetries legacy option mapping', () => {
+  const withRetryMock = withRetry as jest.MockedFunction<typeof withRetry>;
+
+  beforeEach(() => {
+    withRetryMock.mockReset();
+    withRetryMock.mockResolvedValue('ok');
+  });
+
+  it('maps maxAttempts to retries and keeps backoff disabled when requested', async () => {
+    const operation = jest.fn(async () => 'done');
+
+    await withRetries(operation, {
+      maxAttempts: 3,
+      delayMs: 25,
+      backoff: false,
+      operationName: 'sync_booking',
+    });
+
+    expect(withRetryMock).toHaveBeenCalledWith(operation, {
+      retries: 2,
+      baseDelayMs: 25,
+      jitter: false,
+      shouldRetry: undefined,
+      operationName: 'sync_booking',
+    });
+  });
+
+  it('prefers maxAttempts over retries and clamps retries at zero', async () => {
+    const operation = jest.fn(async () => 'done');
+
+    await withRetries(operation, {
+      retries: 9,
+      maxAttempts: 0,
+    });
+
+    expect(withRetryMock).toHaveBeenCalledWith(operation, {
+      retries: 0,
+      baseDelayMs: undefined,
+      jitter: true,
+      shouldRetry: undefined,
+      operationName: undefined,
+    });
+  });
+
+  it('passes through shouldRetry and defaults jitter to true', async () => {
+    const operation = jest.fn(async () => 'done');
+    const shouldRetry = jest.fn(() => true);
+
+    await withRetries(operation, {
+      baseDelayMs: 10,
+      shouldRetry,
+    });
+
+    expect(withRetryMock).toHaveBeenCalledWith(operation, {
+      retries: undefined,
+      baseDelayMs: 10,
+      jitter: true,
+      shouldRetry,
+      operationName: undefined,
+    });
+  });
+
+  it('re-exports sleep from ErrorHandlingService', () => {
+    const mockedSleep = jest.requireMock('../../src/services/ErrorHandlingService').sleep;
+    expect(sleep).toBe(mockedSleep);
+  });
+});


### PR DESCRIPTION
## Summary
- Added focused unit tests for backend retry compatibility wrapper (withRetries).
- Validated legacy option mapping to withRetry (maxAttempts, retries, delayMs/baseDelayMs, backoff, shouldRetry, operationName).
- Added coverage for sleep re-export contract.

## Changes Made
- New test file: packages/backend/tests/services/retry.test.ts

## Testing
- npm test -- tests/services/retry.test.ts
- npx eslint src/services/retry.ts
- npx tsc --noEmit --pretty false src/services/retry.ts --target ES2022 --module commonjs --moduleResolution node --esModuleInterop --types node
- npx tsc --noEmit --pretty false tests/services/retry.test.ts --target ES2022 --module commonjs --moduleResolution node --esModuleInterop --types node,jest

## Checklist
- [x] Scoped changes to issue #363 only
- [x] Added/updated tests for retry logic
- [x] No public API contract changes

Closes Traqora/Traqora#363.