### PR TITLE
feat(search): add search history and saved searches

### DIFF
--- a/packages/backend/src/api/routes/flights.ts
+++ b/packages/backend/src/api/routes/flights.ts
@@ -7,6 +7,9 @@ import { FlightSearchService } from "../../services/flightSearchService";
 import { CurrencyService } from "../../services/currencyService";
 import { FareRulesService, FareClass } from "../../services/fareRulesService";
 import { BadRequestError } from "../../utils/errors";
+import { requireAuth } from "../../middleware/authMiddleware";
+import { SearchHistoryEntry } from "../../db/entities/SearchHistoryEntry";
+import { SavedSearch } from "../../db/entities/SavedSearch";
 
 const searchQuerySchema = z
   .object({
@@ -65,12 +68,35 @@ const convertSchema = z.object({
   to: z.string().length(3),
 });
 
+const searchMemoryPayloadSchema = z.object({
+  from: z.string().trim().length(3).transform((value) => value.toUpperCase()),
+  to: z.string().trim().length(3).transform((value) => value.toUpperCase()),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  passengers: z.coerce.number().int().min(1).max(9),
+  class: z.enum(["economy", "premium_economy", "business", "first"]).default("economy"),
+});
+
+const savedSearchSchema = searchMemoryPayloadSchema.extend({
+  name: z.string().trim().max(80).optional().or(z.literal("")),
+});
+
+const HISTORY_LIMIT = 10;
+const HISTORY_PRUNE_KEEP = 50;
+const SAVED_SEARCH_LIMIT = 25;
+
 export const createFlightRoutes = (
   flightSearchService: FlightSearchService,
   searchRateLimitMiddleware?: any,
 ) => {
   const router = Router();
   const currencyService = CurrencyService.getInstance();
+  const ensureAuthenticatedUser = (req: Request) => {
+    const walletAddress = req.user?.walletAddress;
+    if (!walletAddress) {
+      throw new BadRequestError("Authenticated user is required");
+    }
+    return walletAddress;
+  };
 
   if (searchRateLimitMiddleware) {
     router.use("/search", searchRateLimitMiddleware);
@@ -143,6 +169,177 @@ export const createFlightRoutes = (
       throw new BadRequestError(error.message || "Invalid request");
     }
   }));
+
+  router.get(
+    "/search/history",
+    requireAuth,
+    asyncHandler(async (req: Request, res: Response) => {
+      const walletAddress = ensureAuthenticatedUser(req);
+      const historyRepo = AppDataSource.getRepository(SearchHistoryEntry);
+      const history = await historyRepo.find({
+        where: { userId: walletAddress },
+        order: { createdAt: "DESC" },
+        take: HISTORY_LIMIT,
+      });
+      res.json({ success: true, data: history });
+    }),
+  );
+
+  router.post(
+    "/search/history",
+    requireAuth,
+    asyncHandler(async (req: Request, res: Response) => {
+      const walletAddress = ensureAuthenticatedUser(req);
+      const parsed = searchMemoryPayloadSchema.safeParse(req.body);
+      if (!parsed.success) {
+        throw new BadRequestError("Validation error", parsed.error.flatten());
+      }
+
+      const historyRepo = AppDataSource.getRepository(SearchHistoryEntry);
+      const payload = parsed.data;
+      const existing = await historyRepo.findOne({
+        where: {
+          userId: walletAddress,
+          fromAirport: payload.from,
+          toAirport: payload.to,
+          departureDate: payload.date,
+          passengers: payload.passengers,
+          cabinClass: payload.class,
+        },
+      });
+
+      if (existing) {
+        await historyRepo.remove(existing);
+      }
+
+      const historyEntry = historyRepo.create({
+        userId: walletAddress,
+        fromAirport: payload.from,
+        toAirport: payload.to,
+        departureDate: payload.date,
+        passengers: payload.passengers,
+        cabinClass: payload.class,
+      });
+      const saved = await historyRepo.save(historyEntry);
+
+      const allIds = await historyRepo.find({
+        where: { userId: walletAddress },
+        select: { id: true },
+        order: { createdAt: "DESC" },
+      });
+      if (allIds.length > HISTORY_PRUNE_KEEP) {
+        const staleIds = allIds.slice(HISTORY_PRUNE_KEEP).map((entry) => entry.id);
+        if (staleIds.length > 0) {
+          await historyRepo.delete(staleIds);
+        }
+      }
+
+      res.status(201).json({ success: true, data: saved });
+    }),
+  );
+
+  router.delete(
+    "/search/history/:id",
+    requireAuth,
+    asyncHandler(async (req: Request, res: Response) => {
+      const walletAddress = ensureAuthenticatedUser(req);
+      const historyRepo = AppDataSource.getRepository(SearchHistoryEntry);
+      const entry = await historyRepo.findOne({ where: { id: req.params.id, userId: walletAddress } });
+      if (!entry) {
+        return res.status(404).json({ success: false, error: { code: "NOT_FOUND", message: "Search history entry not found" } });
+      }
+      await historyRepo.remove(entry);
+      return res.status(204).send();
+    }),
+  );
+
+  router.get(
+    "/saved-searches",
+    requireAuth,
+    asyncHandler(async (req: Request, res: Response) => {
+      const walletAddress = ensureAuthenticatedUser(req);
+      const savedSearchRepo = AppDataSource.getRepository(SavedSearch);
+      const savedSearches = await savedSearchRepo.find({
+        where: { userId: walletAddress },
+        order: { updatedAt: "DESC" },
+      });
+      res.json({ success: true, data: savedSearches });
+    }),
+  );
+
+  router.post(
+    "/saved-searches",
+    requireAuth,
+    asyncHandler(async (req: Request, res: Response) => {
+      const walletAddress = ensureAuthenticatedUser(req);
+      const parsed = savedSearchSchema.safeParse(req.body);
+      if (!parsed.success) {
+        throw new BadRequestError("Validation error", parsed.error.flatten());
+      }
+
+      const savedSearchRepo = AppDataSource.getRepository(SavedSearch);
+      const existingCount = await savedSearchRepo.count({ where: { userId: walletAddress } });
+      if (existingCount >= SAVED_SEARCH_LIMIT) {
+        throw new BadRequestError(`Saved search limit reached (${SAVED_SEARCH_LIMIT})`);
+      }
+
+      const payload = parsed.data;
+      const savedSearch = savedSearchRepo.create({
+        userId: walletAddress,
+        name: payload.name?.trim() || null,
+        fromAirport: payload.from,
+        toAirport: payload.to,
+        departureDate: payload.date,
+        passengers: payload.passengers,
+        cabinClass: payload.class,
+      });
+      const saved = await savedSearchRepo.save(savedSearch);
+      res.status(201).json({ success: true, data: saved });
+    }),
+  );
+
+  router.put(
+    "/saved-searches/:id",
+    requireAuth,
+    asyncHandler(async (req: Request, res: Response) => {
+      const walletAddress = ensureAuthenticatedUser(req);
+      const parsed = savedSearchSchema.safeParse(req.body);
+      if (!parsed.success) {
+        throw new BadRequestError("Validation error", parsed.error.flatten());
+      }
+
+      const savedSearchRepo = AppDataSource.getRepository(SavedSearch);
+      const savedSearch = await savedSearchRepo.findOne({ where: { id: req.params.id, userId: walletAddress } });
+      if (!savedSearch) {
+        return res.status(404).json({ success: false, error: { code: "NOT_FOUND", message: "Saved search not found" } });
+      }
+
+      const payload = parsed.data;
+      savedSearch.name = payload.name?.trim() || null;
+      savedSearch.fromAirport = payload.from;
+      savedSearch.toAirport = payload.to;
+      savedSearch.departureDate = payload.date;
+      savedSearch.passengers = payload.passengers;
+      savedSearch.cabinClass = payload.class;
+      const updated = await savedSearchRepo.save(savedSearch);
+      res.json({ success: true, data: updated });
+    }),
+  );
+
+  router.delete(
+    "/saved-searches/:id",
+    requireAuth,
+    asyncHandler(async (req: Request, res: Response) => {
+      const walletAddress = ensureAuthenticatedUser(req);
+      const savedSearchRepo = AppDataSource.getRepository(SavedSearch);
+      const savedSearch = await savedSearchRepo.findOne({ where: { id: req.params.id, userId: walletAddress } });
+      if (!savedSearch) {
+        return res.status(404).json({ success: false, error: { code: "NOT_FOUND", message: "Saved search not found" } });
+      }
+      await savedSearchRepo.remove(savedSearch);
+      return res.status(204).send();
+    }),
+  );
 
   router.get(
     "/price-trend",

--- a/packages/backend/src/db/dataSource.ts
+++ b/packages/backend/src/db/dataSource.ts
@@ -24,6 +24,7 @@ import { CheckIn } from "./entities/CheckIn";
 import { BiometricCredential } from "./entities/BiometricCredential";
 import { SearchHistoryEntry } from "./entities/SearchHistoryEntry";
 import { SavedSearch } from "./entities/SavedSearch";
+import { UserProfile } from "./entities/UserProfile";
 
 const isTest = process.env.NODE_ENV === "test";
 
@@ -57,6 +58,7 @@ export const AppDataSource = new DataSource(
         BiometricCredential,
         SearchHistoryEntry,
         SavedSearch,
+        UserProfile,
       ],
       logging: false,
     }
@@ -88,6 +90,7 @@ export const AppDataSource = new DataSource(
         BiometricCredential,
         SearchHistoryEntry,
         SavedSearch,
+        UserProfile,
       ],
       migrations: [__dirname + "/migrations/*.{js,ts}"],
       ssl:

--- a/packages/backend/src/db/dataSource.ts
+++ b/packages/backend/src/db/dataSource.ts
@@ -22,6 +22,8 @@ import { InsurancePolicy } from "./entities/InsurancePolicy";
 import { InsuranceClaim } from "./entities/InsuranceClaim";
 import { CheckIn } from "./entities/CheckIn";
 import { BiometricCredential } from "./entities/BiometricCredential";
+import { SearchHistoryEntry } from "./entities/SearchHistoryEntry";
+import { SavedSearch } from "./entities/SavedSearch";
 
 const isTest = process.env.NODE_ENV === "test";
 
@@ -53,6 +55,8 @@ export const AppDataSource = new DataSource(
         InsuranceClaim,
         CheckIn,
         BiometricCredential,
+        SearchHistoryEntry,
+        SavedSearch,
       ],
       logging: false,
     }
@@ -82,6 +86,8 @@ export const AppDataSource = new DataSource(
         InsuranceClaim,
         CheckIn,
         BiometricCredential,
+        SearchHistoryEntry,
+        SavedSearch,
       ],
       migrations: [__dirname + "/migrations/*.{js,ts}"],
       ssl:

--- a/packages/backend/src/db/entities/SavedSearch.ts
+++ b/packages/backend/src/db/entities/SavedSearch.ts
@@ -1,0 +1,36 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { SearchCabinClass } from './SearchHistoryEntry';
+
+@Entity({ name: 'saved_searches' })
+@Index('idx_saved_searches_user_updated_at', ['userId', 'updatedAt'])
+export class SavedSearch {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'varchar', length: 128 })
+  userId!: string;
+
+  @Column({ type: 'varchar', length: 80, nullable: true })
+  name!: string | null;
+
+  @Column({ type: 'varchar', length: 3 })
+  fromAirport!: string;
+
+  @Column({ type: 'varchar', length: 3 })
+  toAirport!: string;
+
+  @Column({ type: 'date' })
+  departureDate!: string;
+
+  @Column({ type: 'integer', default: 1 })
+  passengers!: number;
+
+  @Column({ type: 'varchar', length: 32, default: 'economy' })
+  cabinClass!: SearchCabinClass;
+
+  @CreateDateColumn({ type: process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamptz' })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ type: process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamptz' })
+  updatedAt!: Date;
+}

--- a/packages/backend/src/db/entities/SearchHistoryEntry.ts
+++ b/packages/backend/src/db/entities/SearchHistoryEntry.ts
@@ -1,0 +1,31 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+export type SearchCabinClass = 'economy' | 'premium_economy' | 'business' | 'first';
+
+@Entity({ name: 'search_history_entries' })
+@Index('idx_search_history_user_created_at', ['userId', 'createdAt'])
+export class SearchHistoryEntry {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'varchar', length: 128 })
+  userId!: string;
+
+  @Column({ type: 'varchar', length: 3 })
+  fromAirport!: string;
+
+  @Column({ type: 'varchar', length: 3 })
+  toAirport!: string;
+
+  @Column({ type: 'date' })
+  departureDate!: string;
+
+  @Column({ type: 'integer', default: 1 })
+  passengers!: number;
+
+  @Column({ type: 'varchar', length: 32, default: 'economy' })
+  cabinClass!: SearchCabinClass;
+
+  @CreateDateColumn({ type: process.env.NODE_ENV === 'test' ? 'datetime' : 'timestamptz' })
+  createdAt!: Date;
+}

--- a/packages/backend/src/db/migrations/1757000000000-CreateSearchHistoryAndSavedSearches.ts
+++ b/packages/backend/src/db/migrations/1757000000000-CreateSearchHistoryAndSavedSearches.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateSearchHistoryAndSavedSearches1757000000000 implements MigrationInterface {
+  name = 'CreateSearchHistoryAndSavedSearches1757000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const isPostgres = queryRunner.connection.options.type === 'postgres';
+    const idDefault = isPostgres ? 'uuid_generate_v4()' : 'lower(hex(randomblob(16)))';
+    const timestampType = isPostgres ? 'timestamptz' : 'datetime';
+    const nowDefault = isPostgres ? 'now()' : 'CURRENT_TIMESTAMP';
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "search_history_entries" (
+        "id" uuid PRIMARY KEY DEFAULT ${idDefault},
+        "userId" varchar(128) NOT NULL,
+        "fromAirport" varchar(3) NOT NULL,
+        "toAirport" varchar(3) NOT NULL,
+        "departureDate" date NOT NULL,
+        "passengers" integer NOT NULL DEFAULT 1,
+        "cabinClass" varchar(32) NOT NULL DEFAULT 'economy',
+        "createdAt" ${timestampType} NOT NULL DEFAULT ${nowDefault}
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_search_history_user_created_at"
+      ON "search_history_entries" ("userId", "createdAt")
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "saved_searches" (
+        "id" uuid PRIMARY KEY DEFAULT ${idDefault},
+        "userId" varchar(128) NOT NULL,
+        "name" varchar(80),
+        "fromAirport" varchar(3) NOT NULL,
+        "toAirport" varchar(3) NOT NULL,
+        "departureDate" date NOT NULL,
+        "passengers" integer NOT NULL DEFAULT 1,
+        "cabinClass" varchar(32) NOT NULL DEFAULT 'economy',
+        "createdAt" ${timestampType} NOT NULL DEFAULT ${nowDefault},
+        "updatedAt" ${timestampType} NOT NULL DEFAULT ${nowDefault}
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "idx_saved_searches_user_updated_at"
+      ON "saved_searches" ("userId", "updatedAt")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE IF EXISTS "saved_searches"');
+    await queryRunner.query('DROP TABLE IF EXISTS "search_history_entries"');
+  }
+}

--- a/packages/backend/tests/integration/flights.search-memory.routes.test.ts
+++ b/packages/backend/tests/integration/flights.search-memory.routes.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+import { createFlightRoutes } from '../../src/api/routes/flights';
+
+jest.mock('../../src/middleware/authMiddleware', () => ({
+  requireAuth: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = { walletAddress: 'GSEARCHUSER123', walletType: 'freighter' };
+    next();
+  },
+}));
+
+type SearchHistoryRow = {
+  id: string;
+  userId: string;
+  fromAirport: string;
+  toAirport: string;
+  departureDate: string;
+  passengers: number;
+  cabinClass: 'economy' | 'premium_economy' | 'business' | 'first';
+  createdAt: Date;
+};
+
+type SavedSearchRow = {
+  id: string;
+  userId: string;
+  name: string | null;
+  fromAirport: string;
+  toAirport: string;
+  departureDate: string;
+  passengers: number;
+  cabinClass: 'economy' | 'premium_economy' | 'business' | 'first';
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+const historyRows: SearchHistoryRow[] = [];
+const savedRows: SavedSearchRow[] = [];
+
+const historyRepo = {
+  find: jest.fn(async (args?: any) => {
+    const userId = args?.where?.userId;
+    const rows = historyRows
+      .filter((row) => (userId ? row.userId === userId : true))
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    if (args?.take) {
+      return rows.slice(0, args.take);
+    }
+    return rows;
+  }),
+  findOne: jest.fn(async ({ where }: any) => {
+    return historyRows.find((row) =>
+      Object.entries(where).every(([key, value]) => (row as Record<string, unknown>)[key] === value),
+    ) || null;
+  }),
+  create: jest.fn((payload: Omit<SearchHistoryRow, 'id' | 'createdAt'>) => ({
+    id: `history-${historyRows.length + 1}`,
+    createdAt: new Date(),
+    ...payload,
+  })),
+  save: jest.fn(async (entry: SearchHistoryRow) => {
+    historyRows.unshift(entry);
+    return entry;
+  }),
+  remove: jest.fn(async (entry: SearchHistoryRow) => {
+    const index = historyRows.findIndex((row) => row.id === entry.id);
+    if (index >= 0) historyRows.splice(index, 1);
+  }),
+  delete: jest.fn(async (ids: string[]) => {
+    for (const id of ids) {
+      const index = historyRows.findIndex((row) => row.id === id);
+      if (index >= 0) historyRows.splice(index, 1);
+    }
+  }),
+};
+
+const savedRepo = {
+  find: jest.fn(async ({ where }: any) => {
+    return savedRows
+      .filter((row) => row.userId === where.userId)
+      .sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+  }),
+  findOne: jest.fn(async ({ where }: any) => {
+    return savedRows.find((row) =>
+      Object.entries(where).every(([key, value]) => (row as Record<string, unknown>)[key] === value),
+    ) || null;
+  }),
+  count: jest.fn(async ({ where }: any) => savedRows.filter((row) => row.userId === where.userId).length),
+  create: jest.fn((payload: Omit<SavedSearchRow, 'id' | 'createdAt' | 'updatedAt'>) => ({
+    id: `saved-${savedRows.length + 1}`,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...payload,
+  })),
+  save: jest.fn(async (entry: SavedSearchRow) => {
+    const existingIndex = savedRows.findIndex((row) => row.id === entry.id);
+    const updated = { ...entry, updatedAt: new Date() };
+    if (existingIndex >= 0) {
+      savedRows[existingIndex] = updated;
+    } else {
+      savedRows.unshift(updated);
+    }
+    return updated;
+  }),
+  remove: jest.fn(async (entry: SavedSearchRow) => {
+    const index = savedRows.findIndex((row) => row.id === entry.id);
+    if (index >= 0) savedRows.splice(index, 1);
+  }),
+};
+
+jest.mock('../../src/db/dataSource', () => ({
+  AppDataSource: {
+    getRepository: (entity: unknown) => {
+      if ((entity as { name?: string })?.name === 'SearchHistoryEntry') return historyRepo;
+      if ((entity as { name?: string })?.name === 'SavedSearch') return savedRepo;
+      throw new Error('Unknown repository');
+    },
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/flights', createFlightRoutes({ searchFlights: jest.fn() } as any));
+
+describe('flight search memory routes', () => {
+  beforeEach(() => {
+    historyRows.splice(0);
+    savedRows.splice(0);
+    jest.clearAllMocks();
+  });
+
+  it('stores and returns search history entries', async () => {
+    const createRes = await request(app).post('/api/v1/flights/search/history').send({
+      from: 'jfk',
+      to: 'lax',
+      date: '2026-09-10',
+      passengers: 2,
+      class: 'economy',
+    });
+
+    expect(createRes.status).toBe(201);
+    expect(createRes.body.data.fromAirport).toBe('JFK');
+
+    const listRes = await request(app).get('/api/v1/flights/search/history');
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.data).toHaveLength(1);
+  });
+
+  it('creates and removes saved searches', async () => {
+    const createRes = await request(app).post('/api/v1/flights/saved-searches').send({
+      name: 'Trip',
+      from: 'JFK',
+      to: 'SEA',
+      date: '2026-10-01',
+      passengers: 1,
+      class: 'business',
+    });
+    expect(createRes.status).toBe(201);
+    const id = createRes.body.data.id;
+
+    const listRes = await request(app).get('/api/v1/flights/saved-searches');
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.data).toHaveLength(1);
+
+    const deleteRes = await request(app).delete(`/api/v1/flights/saved-searches/${id}`);
+    expect(deleteRes.status).toBe(204);
+  });
+});

--- a/packages/client/app/search/page.tsx
+++ b/packages/client/app/search/page.tsx
@@ -2,10 +2,11 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
-import { Plane, Calendar, BarChart3, Keyboard } from "lucide-react"
+import { Plane, Calendar, BarChart3, Keyboard, Bookmark, History, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { useToast } from "@/hooks/use-toast"
 
 import { SearchForm, SearchFormData } from "@/components/flight-search/search-form"
@@ -15,6 +16,7 @@ import { FlexibleDateSearchPanel } from "@/components/flight-search/FlexibleDate
 import { PriceTrendSparkline } from "@/components/flight-search/price-trend-sparkline"
 import { FlightComparison } from "@/components/flight-comparison"
 import { useFlightSearch } from "@/hooks/use-flight-search"
+import { apiClient, SavedSearch, SearchHistoryEntry } from "@/lib/api"
 
 const FILTERS_STORAGE_KEY = "traqora:flight-search-filters"
 const MAX_COMPARE = 3
@@ -54,6 +56,16 @@ function departureWindowToHours(window: string): [number, number] | null {
     default:
       return null
   }
+
+  function toSearchMemoryPayload(query: SearchFormData) {
+    return {
+      from: query.from.toUpperCase(),
+      to: query.to.toUpperCase(),
+      date: query.departure,
+      passengers: parseInt(query.passengers, 10),
+      class: query.class,
+    }
+  }
 }
 
 export default function SearchPage() {
@@ -68,11 +80,38 @@ export default function SearchPage() {
   const [lastQuery, setLastQuery] = useState<SearchFormData | null>(null)
   const [compareIds, setCompareIds] = useState<string[]>([])
   const [showComparison, setShowComparison] = useState(false)
+  const [searchHistory, setSearchHistory] = useState<SearchHistoryEntry[]>([])
+  const [savedSearches, setSavedSearches] = useState<SavedSearch[]>([])
+  const [isMemoryLoading, setIsMemoryLoading] = useState(false)
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     setFilters(loadStoredFilters())
+  }, [])
+
+  useEffect(() => {
+    let isMounted = true
+    const loadSearchMemory = async () => {
+      setIsMemoryLoading(true)
+      const [historyResponse, savedResponse] = await Promise.all([
+        apiClient.getSearchHistory(),
+        apiClient.getSavedSearches(),
+      ])
+      if (!isMounted) return
+
+      if (historyResponse.success) {
+        setSearchHistory(historyResponse.data)
+      }
+      if (savedResponse.success) {
+        setSavedSearches(savedResponse.data)
+      }
+      setIsMemoryLoading(false)
+    }
+    loadSearchMemory()
+    return () => {
+      isMounted = false
+    }
   }, [])
 
   const runSearch = useCallback(
@@ -128,6 +167,12 @@ export default function SearchPage() {
     })
     router.replace(`/search?${params.toString()}`)
     runSearch(data, filters)
+
+    void apiClient.addSearchHistory(toSearchMemoryPayload(data)).then((response) => {
+      if (response.success) {
+        setSearchHistory((prev) => [response.data, ...prev.filter((item) => item.id !== response.data.id)].slice(0, 10))
+      }
+    })
   }
 
   const handleDateSelect = (date: string) => {
@@ -212,6 +257,21 @@ export default function SearchPage() {
   }, [flights])
 
   const selectedFlightsForComparison = flights.filter((f) => compareIds.includes(f.id))
+  const applySearchMemory = (query: SearchFormData) => {
+    handleSearch(query)
+  }
+
+  const saveCurrentSearch = async () => {
+    if (!lastQuery) return
+    const name = typeof window !== "undefined" ? window.prompt("Optional name for this saved search") || "" : ""
+    const response = await apiClient.createSavedSearch({ ...toSearchMemoryPayload(lastQuery), name })
+    if (!response.success) {
+      toast({ title: "Failed to save search", description: response.error.message, variant: "destructive" })
+      return
+    }
+    setSavedSearches((prev) => [response.data, ...prev])
+    toast({ title: "Search saved" })
+  }
 
   return (
     <div className="min-h-screen bg-background">
@@ -254,6 +314,98 @@ export default function SearchPage() {
             />
           </TabsContent>
         </Tabs>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <Card>
+            <CardHeader className="pb-3">
+              <CardTitle className="text-base flex items-center gap-2">
+                <History className="h-4 w-4 text-primary" />
+                Recent Searches
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {isMemoryLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+              {!isMemoryLoading && searchHistory.length === 0 && (
+                <p className="text-sm text-muted-foreground">No recent searches yet.</p>
+              )}
+              {searchHistory.map((item) => (
+                <div key={item.id} className="flex items-center justify-between gap-2 rounded border px-3 py-2">
+                  <button
+                    className="text-left text-sm hover:underline"
+                    onClick={() =>
+                      applySearchMemory({
+                        from: item.fromAirport,
+                        to: item.toAirport,
+                        departure: item.departureDate,
+                        passengers: String(item.passengers),
+                        class: item.cabinClass,
+                      })
+                    }
+                  >
+                    {item.fromAirport} → {item.toAirport} · {item.departureDate}
+                  </button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={async () => {
+                      const response = await apiClient.deleteSearchHistory(item.id)
+                      if (response.success) setSearchHistory((prev) => prev.filter((entry) => entry.id !== item.id))
+                    }}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader className="pb-3 flex flex-row items-center justify-between">
+              <CardTitle className="text-base flex items-center gap-2">
+                <Bookmark className="h-4 w-4 text-primary" />
+                Saved Searches
+              </CardTitle>
+              <Button size="sm" variant="outline" onClick={saveCurrentSearch} disabled={!lastQuery}>
+                Save Current
+              </Button>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {isMemoryLoading && <p className="text-sm text-muted-foreground">Loading…</p>}
+              {!isMemoryLoading && savedSearches.length === 0 && (
+                <p className="text-sm text-muted-foreground">No saved searches yet.</p>
+              )}
+              {savedSearches.map((item) => (
+                <div key={item.id} className="flex items-center justify-between gap-2 rounded border px-3 py-2">
+                  <button
+                    className="text-left text-sm hover:underline"
+                    onClick={() =>
+                      applySearchMemory({
+                        from: item.fromAirport,
+                        to: item.toAirport,
+                        departure: item.departureDate,
+                        passengers: String(item.passengers),
+                        class: item.cabinClass,
+                      })
+                    }
+                  >
+                    <span className="font-medium">{item.name || `${item.fromAirport} → ${item.toAirport}`}</span>
+                    <span className="text-muted-foreground"> · {item.departureDate}</span>
+                  </button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={async () => {
+                      const response = await apiClient.deleteSavedSearch(item.id)
+                      if (response.success) setSavedSearches((prev) => prev.filter((entry) => entry.id !== item.id))
+                    }}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
 
         {lastQuery && <PriceTrendSparkline from={lastQuery.from} to={lastQuery.to} />}
 

--- a/packages/client/lib/api.ts
+++ b/packages/client/lib/api.ts
@@ -101,6 +101,38 @@ export interface FlightSearchResponse {
   }
 }
 
+export interface SearchMemoryQuery {
+  from: string
+  to: string
+  date: string
+  passengers: number
+  class: "economy" | "premium_economy" | "business" | "first"
+}
+
+export interface SearchHistoryEntry {
+  id: string
+  userId: string
+  fromAirport: string
+  toAirport: string
+  departureDate: string
+  passengers: number
+  cabinClass: SearchMemoryQuery["class"]
+  createdAt: string
+}
+
+export interface SavedSearch {
+  id: string
+  userId: string
+  name: string | null
+  fromAirport: string
+  toAirport: string
+  departureDate: string
+  passengers: number
+  cabinClass: SearchMemoryQuery["class"]
+  createdAt: string
+  updatedAt: string
+}
+
 export interface CreateBookingRequest {
   flightId: string
   passengerCount: number
@@ -465,6 +497,51 @@ export async function getPriceTrend(from: string, to: string, days = 14): Promis
   return apiGet<PriceTrend>(`/api/flights/price-trend?from=${from}&to=${to}&days=${days}`)
 }
 
+export async function getSearchHistory(): Promise<SearchHistoryEntry[]> {
+  const body = await authedFetch('/api/v1/flights/search/history')
+  return body.data as SearchHistoryEntry[]
+}
+
+export async function createSearchHistoryEntry(payload: SearchMemoryQuery): Promise<SearchHistoryEntry> {
+  const body = await authedFetch('/api/v1/flights/search/history', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  return body.data as SearchHistoryEntry
+}
+
+export async function deleteSearchHistoryEntry(id: string): Promise<void> {
+  await authedFetch(`/api/v1/flights/search/history/${id}`, { method: 'DELETE' })
+}
+
+export async function getSavedSearches(): Promise<SavedSearch[]> {
+  const body = await authedFetch('/api/v1/flights/saved-searches')
+  return body.data as SavedSearch[]
+}
+
+export async function createSavedSearch(payload: SearchMemoryQuery & { name?: string }): Promise<SavedSearch> {
+  const body = await authedFetch('/api/v1/flights/saved-searches', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  return body.data as SavedSearch
+}
+
+export async function updateSavedSearch(
+  id: string,
+  payload: SearchMemoryQuery & { name?: string },
+): Promise<SavedSearch> {
+  const body = await authedFetch(`/api/v1/flights/saved-searches/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+  })
+  return body.data as SavedSearch
+}
+
+export async function deleteSavedSearch(id: string): Promise<void> {
+  await authedFetch(`/api/v1/flights/saved-searches/${id}`, { method: 'DELETE' })
+}
+
 export async function getInsuranceQuotes(
   tripCostCents: number,
   destination: string,
@@ -728,6 +805,72 @@ export const apiClient = {
     try {
       const data = await getCarbonStats(userId)
       return { success: true, data }
+    } catch (error: any) {
+      return { success: false, error: { message: error.message } }
+    }
+  },
+
+  getSearchHistory: async (): Promise<ApiResult<SearchHistoryEntry[]>> => {
+    try {
+      const data = await getSearchHistory()
+      return { success: true, data }
+    } catch (error: any) {
+      return { success: false, error: { message: error.message } }
+    }
+  },
+
+  addSearchHistory: async (payload: SearchMemoryQuery): Promise<ApiResult<SearchHistoryEntry>> => {
+    try {
+      const data = await createSearchHistoryEntry(payload)
+      return { success: true, data }
+    } catch (error: any) {
+      return { success: false, error: { message: error.message } }
+    }
+  },
+
+  deleteSearchHistory: async (id: string): Promise<ApiResult<null>> => {
+    try {
+      await deleteSearchHistoryEntry(id)
+      return { success: true, data: null }
+    } catch (error: any) {
+      return { success: false, error: { message: error.message } }
+    }
+  },
+
+  getSavedSearches: async (): Promise<ApiResult<SavedSearch[]>> => {
+    try {
+      const data = await getSavedSearches()
+      return { success: true, data }
+    } catch (error: any) {
+      return { success: false, error: { message: error.message } }
+    }
+  },
+
+  createSavedSearch: async (payload: SearchMemoryQuery & { name?: string }): Promise<ApiResult<SavedSearch>> => {
+    try {
+      const data = await createSavedSearch(payload)
+      return { success: true, data }
+    } catch (error: any) {
+      return { success: false, error: { message: error.message } }
+    }
+  },
+
+  updateSavedSearch: async (
+    id: string,
+    payload: SearchMemoryQuery & { name?: string },
+  ): Promise<ApiResult<SavedSearch>> => {
+    try {
+      const data = await updateSavedSearch(id, payload)
+      return { success: true, data }
+    } catch (error: any) {
+      return { success: false, error: { message: error.message } }
+    }
+  },
+
+  deleteSavedSearch: async (id: string): Promise<ApiResult<null>> => {
+    try {
+      await deleteSavedSearch(id)
+      return { success: true, data: null }
     } catch (error: any) {
       return { success: false, error: { message: error.message } }
     }

--- a/packages/client/tests/search-memory-api.test.ts
+++ b/packages/client/tests/search-memory-api.test.ts
@@ -1,0 +1,79 @@
+import { apiClient } from '../lib/api'
+
+describe('search memory api client', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    localStorage.setItem('traqora-auth', JSON.stringify({ state: { accessToken: 'test-token' } }))
+    global.fetch = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('loads search history', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: 'history-1',
+            userId: 'GSEARCHUSER123',
+            fromAirport: 'JFK',
+            toAirport: 'LAX',
+            departureDate: '2026-09-01',
+            passengers: 2,
+            cabinClass: 'economy',
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      }),
+    })
+
+    const response = await apiClient.getSearchHistory()
+    expect(response.success).toBe(true)
+    if (response.success) {
+      expect(response.data[0].fromAirport).toBe('JFK')
+    }
+  })
+
+  it('creates a saved search', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          id: 'saved-1',
+          userId: 'GSEARCHUSER123',
+          name: 'Test search',
+          fromAirport: 'JFK',
+          toAirport: 'SEA',
+          departureDate: '2026-10-02',
+          passengers: 1,
+          cabinClass: 'business',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      }),
+    })
+
+    const response = await apiClient.createSavedSearch({
+      name: 'Test search',
+      from: 'JFK',
+      to: 'SEA',
+      date: '2026-10-02',
+      passengers: 1,
+      class: 'business',
+    })
+
+    expect(response.success).toBe(true)
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/flights/saved-searches'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-token',
+        }),
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Problem
- Flight search had no persistent recent history or reusable saved searches for authenticated users.

## Solution
- Added backend persistence for search_history_entries and saved_searches with migration and TypeORM entities.
- Added authenticated flight route endpoints to create/list/delete history and create/list/update/delete saved searches.
- Added frontend API client methods and wired /search page UI for recent searches and saved searches with apply/remove/save actions.

## Testing
- npm run -w packages/backend test -- --runInBand tests/integration/flights.search-memory.routes.test.ts
- npm run -w packages/client test -- --runInBand tests/search-memory-api.test.ts

## Risks / Notes
- Endpoints require authenticated user context (Bearer token), and degrade gracefully in UI when unauthenticated.

Closes Traqora/Traqora#366