### PR TITLE
feat(bookings): enforce IATA name format validation on passenger name fields

### DIFF
--- a/packages/backend/src/api/routes/bookings.ts
+++ b/packages/backend/src/api/routes/bookings.ts
@@ -23,10 +23,20 @@ import { baggageService, RESTRICTION_NOTES } from "../../services/baggageService
 
 const router = Router();
 
+// IATA name format: letters, spaces, hyphens, and apostrophes only
+const iatanameRegex = /^[A-Za-z\s'\-]+$/;
+const nameField = (label: string) =>
+  z
+    .string()
+    .min(1, `${label} is required`)
+    .max(100, `${label} must be 100 characters or fewer`)
+    .trim()
+    .regex(iatanameRegex, `${label} may only contain letters, spaces, hyphens, and apostrophes`);
+
 const passengerSchema = z.object({
   email: z.string().email(),
-  firstName: z.string().min(1),
-  lastName: z.string().min(1),
+  firstName: nameField("First name"),
+  lastName: nameField("Last name"),
   middleName: z.string().optional(),
   title: z.string().optional(),
   suffix: z.string().optional(),
@@ -38,8 +48,8 @@ const passengerSchema = z.object({
 
 const passengerUpdateSchema = z.object({
   email: z.string().email().optional(),
-  firstName: z.string().min(1).optional(),
-  lastName: z.string().min(1).optional(),
+  firstName: nameField("First name").optional(),
+  lastName: nameField("Last name").optional(),
   middleName: z.string().optional(),
   title: z.string().optional(),
   suffix: z.string().optional(),
@@ -52,9 +62,9 @@ const passengerUpdateSchema = z.object({
 const nameCorrectionSchema = z.object({
   correctedName: z.object({
     title: z.string().optional(),
-    firstName: z.string().min(1),
+    firstName: nameField("First name"),
     middleName: z.string().optional(),
-    lastName: z.string().min(1),
+    lastName: nameField("Last name"),
     suffix: z.string().optional(),
   }),
   reason: z.string().min(10),

--- a/packages/backend/src/services/__tests__/passengerNameValidation.test.ts
+++ b/packages/backend/src/services/__tests__/passengerNameValidation.test.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+// Mirror the validation helper from the route so we can test it independently
+const iatanameRegex = /^[A-Za-z\s'\-]+$/;
+const nameField = (label: string) =>
+  z
+    .string()
+    .min(1, `${label} is required`)
+    .max(100, `${label} must be 100 characters or fewer`)
+    .trim()
+    .regex(iatanameRegex, `${label} may only contain letters, spaces, hyphens, and apostrophes`);
+
+const passengerNameSchema = z.object({
+  firstName: nameField("First name"),
+  lastName: nameField("Last name"),
+});
+
+describe("passenger name IATA validation", () => {
+  it("accepts standard names", () => {
+    expect(passengerNameSchema.safeParse({ firstName: "John", lastName: "Doe" }).success).toBe(true);
+  });
+
+  it("accepts hyphenated names", () => {
+    expect(passengerNameSchema.safeParse({ firstName: "Mary-Anne", lastName: "Smith-Jones" }).success).toBe(true);
+  });
+
+  it("accepts names with apostrophes", () => {
+    expect(passengerNameSchema.safeParse({ firstName: "O'Brien", lastName: "D'Angelo" }).success).toBe(true);
+  });
+
+  it("accepts names with internal spaces (compound given name)", () => {
+    expect(passengerNameSchema.safeParse({ firstName: "Jean Pierre", lastName: "De La Cruz" }).success).toBe(true);
+  });
+
+  it("trims leading and trailing whitespace before validation", () => {
+    const result = passengerNameSchema.safeParse({ firstName: "  Alice  ", lastName: "  Walker  " });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.firstName).toBe("Alice");
+      expect(result.data.lastName).toBe("Walker");
+    }
+  });
+
+  it("rejects names with digits", () => {
+    expect(passengerNameSchema.safeParse({ firstName: "John2", lastName: "Doe" }).success).toBe(false);
+  });
+
+  it("rejects names with special characters not allowed by IATA", () => {
+    expect(passengerNameSchema.safeParse({ firstName: "J@ne", lastName: "Doe" }).success).toBe(false);
+  });
+
+  it("rejects empty firstName", () => {
+    expect(passengerNameSchema.safeParse({ firstName: "", lastName: "Doe" }).success).toBe(false);
+  });
+
+  it("rejects empty lastName", () => {
+    expect(passengerNameSchema.safeParse({ firstName: "Jane", lastName: "" }).success).toBe(false);
+  });
+
+  it("rejects firstName longer than 100 characters", () => {
+    const longName = "A".repeat(101);
+    expect(passengerNameSchema.safeParse({ firstName: longName, lastName: "Doe" }).success).toBe(false);
+  });
+
+  it("accepts firstName of exactly 100 characters", () => {
+    const maxName = "A".repeat(100);
+    expect(passengerNameSchema.safeParse({ firstName: maxName, lastName: "Doe" }).success).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #343
Closes #342
Closes #341
Closes #336

## Problem

Passenger `firstName` and `lastName` fields in `passengerSchema`, `passengerUpdateSchema`, and `nameCorrectionSchema` only enforced `.min(1)` — meaning names containing digits, symbols, or excessive whitespace could be stored. This violates IATA naming conventions (letters, spaces, hyphens, and apostrophes only) and causes downstream failures at airline check-in and ticketing APIs that enforce the same standard.

## Changes

| File | Change |
|------|--------|
| `packages/backend/src/api/routes/bookings.ts` | Adds a shared `nameField()` helper applying `.trim()`, `.max(100)`, and an IATA character-allowlist regex (`/^[A-Za-z\s'\-]+$/`) to `firstName`/`lastName` in all three name-bearing schemas |
| `packages/backend/src/services/__tests__/passengerNameValidation.test.ts` | 11 unit tests covering valid formats (hyphenated, apostrophe, compound, whitespace trimming) and invalid inputs (digits, symbols, empty, over-length) |

## How it works

A `nameField(label)` factory builds the full Zod chain once and is reused across schemas:

```ts
const nameField = (label: string) =>
  z.string()
    .min(1, `${label} is required`)
    .max(100, `${label} must be 100 characters or fewer`)
    .trim()
    .regex(/^[A-Za-z\s'\-]+$/, `${label} may only contain letters, spaces, hyphens, and apostrophes`);
```

- `passengerSchema` — applied to `firstName` / `lastName` at booking creation
- `passengerUpdateSchema` — applied with `.optional()` for partial PATCH updates
- `nameCorrectionSchema` — applied to `correctedName.firstName` / `correctedName.lastName` so correction requests also enforce the same standard