### PR TITLE
test: add unit tests for loyalty tier progression and baggage allowance

### DIFF
--- a/packages/backend/tests/services/baggageService.test.ts
+++ b/packages/backend/tests/services/baggageService.test.ts
@@ -1,0 +1,89 @@
+import { BaggageService, RESTRICTION_NOTES } from '../../src/services/baggageService';
+
+describe('BaggageService', () => {
+  let svc: BaggageService;
+
+  beforeEach(() => {
+    svc = new BaggageService();
+  });
+
+  describe('getAllowance', () => {
+    it('returns economy defaults for an unknown airline', () => {
+      const a = svc.getAllowance('XX', 'economy');
+      expect(a.checkedBags).toBe(1);
+      expect(a.checkedWeightKgPerBag).toBe(23);
+      expect(a.carryOnBags).toBe(1);
+    });
+
+    it('returns more checked bags for business class', () => {
+      const economy = svc.getAllowance('XX', 'economy');
+      const business = svc.getAllowance('XX', 'business');
+      expect(business.checkedBags).toBeGreaterThanOrEqual(economy.checkedBags);
+      expect(business.checkedWeightKgPerBag).toBeGreaterThan(economy.checkedWeightKgPerBag);
+    });
+
+    it('returns the most generous allowance for first class', () => {
+      const first = svc.getAllowance('XX', 'first');
+      expect(first.checkedBags).toBeGreaterThanOrEqual(svc.getAllowance('XX', 'business').checkedBags);
+    });
+
+    it('applies airline-specific override for Delta economy (2 bags)', () => {
+      const a = svc.getAllowance('DL', 'economy');
+      expect(a.checkedBags).toBe(2);
+    });
+
+    it('applies airline-specific override for BA economy', () => {
+      const a = svc.getAllowance('BA', 'economy');
+      expect(a.checkedBags).toBe(1);
+      expect(a.checkedWeightKgPerBag).toBe(23);
+    });
+
+    it('is case-insensitive for airline codes', () => {
+      expect(svc.getAllowance('dl', 'economy')).toEqual(svc.getAllowance('DL', 'economy'));
+    });
+  });
+
+  describe('calculateExcessFee', () => {
+    it('returns zero fee when bags and weight are within allowance', () => {
+      const result = svc.calculateExcessFee('XX', 'economy', 1, 20);
+      expect(result.feeCents).toBe(0);
+      expect(result.excessBags).toBe(0);
+      expect(result.excessWeightKg).toBe(0);
+    });
+
+    it('charges per excess bag', () => {
+      const result = svc.calculateExcessFee('XX', 'economy', 3, 20);
+      expect(result.excessBags).toBe(2);
+      expect(result.feeCents).toBeGreaterThan(0);
+    });
+
+    it('charges for weight over the per-bag limit', () => {
+      const result = svc.calculateExcessFee('XX', 'economy', 1, 30);
+      expect(result.excessWeightKg).toBeGreaterThan(0);
+      expect(result.feeCents).toBeGreaterThan(0);
+    });
+
+    it('charges both excess bag and weight fees when both are exceeded', () => {
+      const bagOnly = svc.calculateExcessFee('XX', 'economy', 3, 20);
+      const weightOnly = svc.calculateExcessFee('XX', 'economy', 1, 30);
+      const both = svc.calculateExcessFee('XX', 'economy', 3, 30);
+      expect(both.feeCents).toBe(bagOnly.feeCents + weightOnly.feeCents);
+    });
+
+    it('returns the allowance in the result', () => {
+      const result = svc.calculateExcessFee('DL', 'economy', 1, 10);
+      expect(result.allowance.checkedBags).toBe(2);
+    });
+  });
+
+  describe('RESTRICTION_NOTES', () => {
+    it('has at least one restriction note', () => {
+      expect(RESTRICTION_NOTES.length).toBeGreaterThan(0);
+    });
+
+    it('includes a note about liquids in carry-on', () => {
+      const hasLiquids = RESTRICTION_NOTES.some(n => n.toLowerCase().includes('liquid'));
+      expect(hasLiquids).toBe(true);
+    });
+  });
+});

--- a/packages/backend/tests/services/loyaltyTiers.test.ts
+++ b/packages/backend/tests/services/loyaltyTiers.test.ts
@@ -1,0 +1,119 @@
+import {
+  getTierInfo,
+  calculateTierProgression,
+  getTierHistoryEntries,
+  TIERS,
+} from '../../src/services/loyalty-tiers';
+import { LoyaltyTier, LoyaltyAccount } from '../../src/types/loyalty';
+
+function makeAccount(overrides: Partial<LoyaltyAccount> = {}): LoyaltyAccount {
+  return {
+    userId: 'user-1',
+    tier: LoyaltyTier.BRONZE,
+    totalPoints: 0,
+    availablePoints: 0,
+    lifetimeBookings: 0,
+    lifetimeSpent: 0,
+    tierUpdatedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+describe('getTierInfo', () => {
+  it('returns the correct TierInfo for each defined tier', () => {
+    for (const tier of Object.values(LoyaltyTier)) {
+      const info = getTierInfo(tier as LoyaltyTier);
+      expect(info).toBeDefined();
+      expect(info!.tier).toBe(tier);
+      expect(info!.benefits.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns undefined for an unknown tier value', () => {
+    expect(getTierInfo('unknown' as LoyaltyTier)).toBeUndefined();
+  });
+
+  it('Diamond tier has the most benefits of all tiers', () => {
+    const diamond = getTierInfo(LoyaltyTier.DIAMOND)!;
+    for (const t of TIERS) {
+      expect(diamond.benefits.length).toBeGreaterThanOrEqual(t.benefits.length);
+    }
+  });
+});
+
+describe('calculateTierProgression', () => {
+  it('returns Bronze as the current tier for a zero-point account', () => {
+    const result = calculateTierProgression(makeAccount({ tier: LoyaltyTier.BRONZE, totalPoints: 0 }));
+    expect(result.currentTier.tier).toBe(LoyaltyTier.BRONZE);
+    expect(result.nextTier).not.toBeNull();
+    expect(result.pointsRemaining).toBeGreaterThan(0);
+    expect(result.progressPercent).toBe(0);
+  });
+
+  it('shows correct points remaining when partway to the next tier', () => {
+    const silver = getTierInfo(LoyaltyTier.SILVER)!;
+    const halfway = Math.floor(silver.minPoints / 2);
+    const result = calculateTierProgression(
+      makeAccount({ tier: LoyaltyTier.BRONZE, totalPoints: halfway }),
+    );
+    expect(result.pointsRemaining).toBe(silver.minPoints - halfway);
+    expect(result.progressPercent).toBeCloseTo(50, 0);
+  });
+
+  it('returns 100% progress and no nextTier for a Diamond account', () => {
+    const diamond = getTierInfo(LoyaltyTier.DIAMOND)!;
+    const result = calculateTierProgression(
+      makeAccount({ tier: LoyaltyTier.DIAMOND, totalPoints: diamond.minPoints }),
+    );
+    expect(result.nextTier).toBeNull();
+    expect(result.pointsRemaining).toBe(0);
+    expect(result.progressPercent).toBe(100);
+  });
+
+  it('clamps progressPercent to 100 when points exceed the next tier threshold', () => {
+    const silver = getTierInfo(LoyaltyTier.SILVER)!;
+    const result = calculateTierProgression(
+      makeAccount({ tier: LoyaltyTier.BRONZE, totalPoints: silver.minPoints + 9999 }),
+    );
+    expect(result.progressPercent).toBe(100);
+  });
+
+  it('falls back gracefully when the account has an unrecognised tier', () => {
+    const result = calculateTierProgression(
+      makeAccount({ tier: 'unknown' as LoyaltyTier, totalPoints: 500 }),
+    );
+    expect(result.currentTier.tier).toBe(LoyaltyTier.BRONZE);
+    expect(result.nextTier).not.toBeNull();
+  });
+});
+
+describe('getTierHistoryEntries', () => {
+  it('maps tier history to named entries in order', () => {
+    const now = new Date();
+    const earlier = new Date(now.getTime() - 86400_000);
+    const history = [
+      { tier: LoyaltyTier.BRONZE, changedAt: earlier },
+      { tier: LoyaltyTier.SILVER, changedAt: now },
+    ];
+    const entries = getTierHistoryEntries(history);
+    expect(entries).toHaveLength(2);
+    expect(entries[0].tier).toBe(LoyaltyTier.BRONZE);
+    expect(entries[0].name).toBe('Bronze');
+    expect(entries[1].tier).toBe(LoyaltyTier.SILVER);
+    expect(entries[1].name).toBe('Silver');
+    expect(entries[1].changedAt).toBe(now);
+  });
+
+  it('returns an empty array for an empty history', () => {
+    expect(getTierHistoryEntries([])).toEqual([]);
+  });
+
+  it('uses "Unknown" as the name for an unrecognised tier in history', () => {
+    const entries = getTierHistoryEntries([
+      { tier: 'legacy_gold' as LoyaltyTier, changedAt: new Date() },
+    ]);
+    expect(entries[0].name).toBe('Unknown');
+  });
+});


### PR DESCRIPTION
Closes #337
Closes #338
Closes #339
Closes #340

Adds unit test coverage for two core service modules that were previously untested:

**`tests/services/loyaltyTiers.test.ts`** (12 tests)
- `getTierInfo`: verifies every tier returns a non-empty benefits list; unknown tier returns undefined; Diamond has the most benefits
- `calculateTierProgression`: zero-point Bronze, mid-tier progress, Diamond ceiling (100%, no next tier), points-exceeded clamp, unknown-tier fallback
- `getTierHistoryEntries`: ordered mapping to named entries, empty history, unknown-tier "Unknown" fallback

**`tests/services/baggageService.test.ts`** (12 tests)
- `getAllowance`: economy defaults, cabin-class ordering, airline overrides (DL, BA), case-insensitive airline codes
- `calculateExcessFee`: within-allowance zero fee, excess bag charges, excess weight charges, combined fees, correct allowance in result
- `RESTRICTION_NOTES`: non-empty list, liquids restriction present

All 24 tests pass.