### PR TITLE
Redis Cluster caching, Sentry feedback widget, real-time flight status, and flight following

### DIFF
--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -96,6 +96,31 @@ DATABASE_URL=sqlite::memory:
 # Type: [URL] | Default: redis://localhost:6379
 REDIS_URL=redis://localhost:6379
 
+# Redis Cluster nodes (optional, issue #335). When set, cache clients connect
+# in Cluster mode instead of using the single-node REDIS_URL above. Format:
+# comma-separated host:port pairs. Matches the `redis-cluster` docker-compose
+# service (ports 7000-7005, run with `docker compose --profile cluster up`).
+# Type: [String] | Default: (None — single-node mode)
+# Example: REDIS_CLUSTER_NODES=localhost:7000,localhost:7001,localhost:7002
+REDIS_CLUSTER_NODES=
+
+# Cache warming job schedule (issue #335) — periodically pre-populates the
+# flight search cache for the most frequently searched routes.
+# Type: [Cron] | Default: */30 * * * * (every 30 minutes)
+CACHE_WARMING_CRON=*/30 * * * *
+# How far back to look for "frequent" searches, in hours.
+# Type: [Number] | Default: 24
+CACHE_WARMING_LOOKBACK_HOURS=24
+# Max number of routes to warm per pass.
+# Type: [Number] | Default: 20
+CACHE_WARMING_TOP_N=20
+
+# Flight status polling job schedule (issue #332) — periodically re-checks
+# status for every flight with an active alert and notifies subscribers of
+# anything that changed since the last known status.
+# Type: [Cron] | Default: */5 * * * * (every 5 minutes)
+FLIGHT_STATUS_POLLING_CRON=*/5 * * * *
+
 # MongoDB Connection URI (optional, for specific logging or read-models).
 # Type: [String] | Default: (None)
 MONGO_URI=

--- a/packages/backend/src/api/routes/flightStatus.ts
+++ b/packages/backend/src/api/routes/flightStatus.ts
@@ -6,8 +6,7 @@ import { BadRequestError, NotFoundError } from '../../utils/errors';
 import { logger } from '../../utils/logger';
 import FlightStatusAlert from '../../models/FlightStatusAlert';
 import { FlightStatusService, FlightStatusUpdate } from '../../services/FlightStatusService';
-import { NotificationService } from '../../services/NotificationService';
-import { getWebSocketServer } from '../../websockets/server';
+import { notifyFlightStatusChange } from '../../services/flightStatusNotifier';
 
 const router = Router();
 
@@ -177,36 +176,7 @@ router.post(
       return res.json({ success: true, data: { flightId, status, notified: 0, changed: false } });
     }
 
-    const subscribers = await FlightStatusAlert.find({ flightId, isActive: true }).exec();
-    const notifier = NotificationService.getInstance();
-    let notifiedCount = 0;
-
-    for (const subscription of subscribers) {
-      const sent = await notifier.sendFlightStatusAlert(subscription.userId, flightId, status, {
-        gate,
-        delayMinutes,
-        reason,
-      });
-      if (sent) {
-        subscription.lastNotifiedAt = new Date();
-        subscription.lastStatus = status;
-        await subscription.save();
-        notifiedCount += 1;
-      }
-    }
-
-    try {
-      const ws = getWebSocketServer();
-      ws.broadcastFlightAlert({
-        flightId,
-        status,
-        gate,
-        delayMinutes,
-        message: buildAlertMessage(flightId, status, { gate, delayMinutes, reason }),
-      });
-    } catch (e) {
-      logger.warn('WebSocket server not ready, skipping flight status broadcast');
-    }
+    const { notifiedCount } = await notifyFlightStatusChange(update);
 
     logger.info(`Flight status change: ${flightId} ${previous?.status ?? 'unknown'} -> ${status}`, {
       notifiedCount,
@@ -219,31 +189,24 @@ router.post(
   }),
 );
 
-function buildAlertMessage(
-  flightId: string,
-  status: string,
-  details: { gate?: string; delayMinutes?: number; reason?: string },
-): string {
-  switch (status) {
-    case 'delayed':
-      return details.delayMinutes
-        ? `Flight ${flightId} is delayed by ${details.delayMinutes} minutes.`
-        : `Flight ${flightId} is delayed.`;
-    case 'cancelled':
-      return details.reason
-        ? `Flight ${flightId} has been cancelled: ${details.reason}`
-        : `Flight ${flightId} has been cancelled.`;
-    case 'gate_changed':
-      return details.gate
-        ? `Flight ${flightId}'s gate has changed to ${details.gate}.`
-        : `Flight ${flightId}'s gate has changed.`;
-    case 'boarding':
-      return `Flight ${flightId} is now boarding.`;
-    case 'departed':
-      return `Flight ${flightId} has departed.`;
-    default:
-      return `Flight ${flightId} status updated: ${status}.`;
-  }
-}
+/**
+ * GET /api/v1/flight-status/:flightId/performance
+ * Historical on-time performance for a flight (issue #332), derived from
+ * recorded status transitions this process has observed.
+ */
+router.get(
+  '/:flightId/performance',
+  asyncHandler(async (req: Request, res: Response) => {
+    const flightId = req.params.flightId;
+    if (!flightId) {
+      throw new BadRequestError('flightId is required');
+    }
+
+    const statusService = FlightStatusService.getInstance();
+    const performance = statusService.getOnTimePerformance(flightId);
+
+    return res.json({ success: true, data: performance });
+  }),
+);
 
 export const flightStatusRoutes = router;

--- a/packages/backend/src/cache/redisClusterConfig.ts
+++ b/packages/backend/src/cache/redisClusterConfig.ts
@@ -1,0 +1,31 @@
+export interface RedisClusterNode {
+  host: string;
+  port: number;
+}
+
+/**
+ * Parses the REDIS_CLUSTER_NODES env format ("host1:port1,host2:port2") into
+ * ioredis Cluster node descriptors. Returns an empty array (single-node /
+ * in-memory mode) for undefined, empty, or all-invalid input (issue #335).
+ */
+export const parseRedisClusterNodes = (raw?: string): RedisClusterNode[] => {
+  if (!raw || raw.trim() === '') {
+    return [];
+  }
+
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .reduce<RedisClusterNode[]>((nodes, entry) => {
+      const [host, portStr] = entry.split(':');
+      const port = Number(portStr);
+
+      if (!host || !Number.isInteger(port) || port <= 0) {
+        return nodes;
+      }
+
+      nodes.push({ host, port });
+      return nodes;
+    }, []);
+};

--- a/packages/backend/src/cache/searchCache.ts
+++ b/packages/backend/src/cache/searchCache.ts
@@ -1,5 +1,6 @@
-import Redis from 'ioredis';
+import Redis, { Cluster } from 'ioredis';
 import { recordCacheOperation } from '../services/metrics';
+import { RedisClusterNode } from './redisClusterConfig';
 
 export interface SearchCache {
   get<T>(key: string): Promise<T | null>;
@@ -62,17 +63,24 @@ export class InMemorySearchCache implements SearchCache {
 export class RedisSearchCache implements SearchCache {
   private readonly memoryFallback: InMemorySearchCache;
   private readonly redisUrl: string;
+  private readonly clusterNodes: RedisClusterNode[];
   private readonly cacheName: string;
-  private redisClient: Redis | null = null;
+  private redisClient: Redis | Cluster | null = null;
   private redisDisabled = false;
 
-  constructor(redisUrl: string, cacheName = 'search-redis') {
+  /**
+   * When clusterNodes is non-empty, connects via ioredis Cluster mode
+   * instead of the single-node redisUrl (issue #335). Existing single-node
+   * behavior is unchanged when clusterNodes is omitted/empty.
+   */
+  constructor(redisUrl: string, cacheName = 'search-redis', clusterNodes: RedisClusterNode[] = []) {
     this.redisUrl = redisUrl;
+    this.clusterNodes = clusterNodes;
     this.cacheName = cacheName;
     this.memoryFallback = new InMemorySearchCache(`${cacheName}-fallback`);
   }
 
-  private async getRedisClient(): Promise<Redis | null> {
+  private async getRedisClient(): Promise<Redis | Cluster | null> {
     if (this.redisDisabled) {
       return null;
     }
@@ -82,11 +90,17 @@ export class RedisSearchCache implements SearchCache {
     }
 
     try {
-      const client = new Redis(this.redisUrl, {
-        lazyConnect: true,
-        maxRetriesPerRequest: 1,
-        enableReadyCheck: true,
-      });
+      const client: Redis | Cluster = this.clusterNodes.length > 0
+        ? new Redis.Cluster(this.clusterNodes, {
+          lazyConnect: true,
+          enableReadyCheck: true,
+          redisOptions: { maxRetriesPerRequest: 1 },
+        })
+        : new Redis(this.redisUrl, {
+          lazyConnect: true,
+          maxRetriesPerRequest: 1,
+          enableReadyCheck: true,
+        });
       await client.connect();
       this.redisClient = client;
       return client;
@@ -178,7 +192,7 @@ export class RedisSearchCache implements SearchCache {
   }
 
   /** Exposes the underlying client so callers can share it with withDistributedLock. */
-  async getClient(): Promise<Redis | null> {
+  async getClient(): Promise<Redis | Cluster | null> {
     return this.getRedisClient();
   }
 }
@@ -191,7 +205,7 @@ export class RedisSearchCache implements SearchCache {
  * consistent with this module's existing single-node-outage tolerance.
  */
 export async function withDistributedLock<T>(
-  redis: Redis | null,
+  redis: Redis | Cluster | null,
   lockKey: string,
   ttlSeconds: number,
   fn: () => Promise<T>,
@@ -227,10 +241,14 @@ const getDurationSeconds = (start: bigint): number => {
   return Number(process.hrtime.bigint() - start) / 1_000_000_000;
 };
 
-export const createSearchCache = (redisUrl?: string, cacheName = 'search'): SearchCache => {
-  if (!redisUrl) {
+export const createSearchCache = (
+  redisUrl?: string,
+  cacheName = 'search',
+  clusterNodes: RedisClusterNode[] = [],
+): SearchCache => {
+  if (!redisUrl && clusterNodes.length === 0) {
     return new InMemorySearchCache(`${cacheName}-memory`);
   }
 
-  return new RedisSearchCache(redisUrl, `${cacheName}-redis`);
+  return new RedisSearchCache(redisUrl || '', `${cacheName}-redis`, clusterNodes);
 };

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -60,6 +60,7 @@ const readConfigFromEnv = () => {
 
     databaseUrl: process.env.DATABASE_URL || 'sqlite::memory:',
     redisUrl: process.env.REDIS_URL || 'redis://localhost:6379',
+    redisClusterNodes: process.env.REDIS_CLUSTER_NODES || undefined,
     mongoUrl: process.env.MONGO_URI,
 
     jwtSecret: getSafeEnvString('JWT_SECRET', 32, 'your-secret-key-change-in-production-at-least-32-chars'),
@@ -194,6 +195,7 @@ export const loadConfig = async (): Promise<Config> => {
 
     databaseUrl: await secretManager.getSecret('DATABASE_URL', 'sqlite::memory:'),
     redisUrl: await secretManager.getSecret('REDIS_URL', 'redis://localhost:6379'),
+    redisClusterNodes: (await secretManager.getSecret('REDIS_CLUSTER_NODES', '')) || undefined,
     mongoUrl: (await secretManager.getSecret('MONGO_URI', '')) || undefined,
 
     jwtSecret,

--- a/packages/backend/src/config/schema.ts
+++ b/packages/backend/src/config/schema.ts
@@ -23,6 +23,10 @@ export const configSchema = z.object({
 
   databaseUrl: z.string().min(1, "Database URL is required"),
   redisUrl: z.string().min(1, "Redis URL is required"),
+  // Comma-separated host:port list (e.g. "localhost:7000,localhost:7001").
+  // When set, cache clients connect in Redis Cluster mode instead of to the
+  // single-node redisUrl (issue #335).
+  redisClusterNodes: z.string().optional(),
   mongoUrl: z.string().optional(),
 
   jwtSecret: z.string().min(32, "JWT secret must be at least 32 characters"),

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -17,6 +17,8 @@ async function startServer() {
       { initDataSource },
       { initWebSocket },
       { initPriceMonitorCron },
+      { initCacheWarmingCron },
+      { initFlightStatusPollingCron },
       { verifyConnectivity },
       contractMonitorModule,
     ] = await Promise.all([
@@ -24,6 +26,8 @@ async function startServer() {
       import('./db/dataSource'),
       import('./websockets/server'),
       import('./jobs/priceMonitor'),
+      import('./jobs/cacheWarmingJob'),
+      import('./jobs/flightStatusPollingJob'),
       import('./utils/health-check'),
       import('./services/contractMonitor'),
     ]);
@@ -40,6 +44,8 @@ async function startServer() {
 
     if (process.env.NODE_ENV !== 'test') {
       await initDataSource();
+      initCacheWarmingCron();
+      initFlightStatusPollingCron();
 
       server.listen(PORT, () => {
         logger.info('Traqora API server started', {

--- a/packages/backend/src/jobs/cacheWarmingJob.ts
+++ b/packages/backend/src/jobs/cacheWarmingJob.ts
@@ -1,0 +1,155 @@
+/**
+ * Cache warming job (issue #335) — periodically pre-populates the flight
+ * search cache for the most frequently searched routes, so the first user
+ * to search a popular route after a cache miss/expiry doesn't pay the full
+ * provider-lookup latency.
+ *
+ * "Frequent" is derived from real usage recorded in search_history_entries
+ * (recent window, configurable via CACHE_WARMING_LOOKBACK_HOURS) rather than
+ * a hardcoded route list, so warming tracks actual traffic patterns.
+ */
+
+import cron from 'node-cron';
+import type { ScheduledTask } from 'node-cron';
+import { AppDataSource } from '../db/dataSource';
+import { SearchHistoryEntry } from '../db/entities/SearchHistoryEntry';
+import { FlightSearchService, createDefaultFlightSearchService } from '../services/flightSearchService';
+import { FlightSearchCriteria } from '../types/flight';
+import { logger } from '../utils/logger';
+
+const CRON_EXPRESSION = process.env.CACHE_WARMING_CRON || '*/30 * * * *';
+const LOOKBACK_HOURS = Number.parseInt(process.env.CACHE_WARMING_LOOKBACK_HOURS || '24', 10);
+const TOP_N = Number.parseInt(process.env.CACHE_WARMING_TOP_N || '20', 10);
+
+interface FrequentRoute {
+  fromAirport: string;
+  toAirport: string;
+  departureDate: string;
+  passengers: number;
+  cabinClass: FlightSearchCriteria['travelClass'];
+  searchCount: number;
+}
+
+export class CacheWarmingJob {
+  private readonly flightSearchService: FlightSearchService;
+  private task: ScheduledTask | null = null;
+
+  constructor(flightSearchService?: FlightSearchService) {
+    this.flightSearchService = flightSearchService ?? createDefaultFlightSearchService();
+  }
+
+  /** Finds the top-N most-searched (route, date, passengers, cabin) combinations in the lookback window. */
+  async findFrequentRoutes(): Promise<FrequentRoute[]> {
+    const since = new Date(Date.now() - LOOKBACK_HOURS * 60 * 60 * 1000);
+
+    const rows = await AppDataSource.getRepository(SearchHistoryEntry)
+      .createQueryBuilder('entry')
+      .select('entry.fromAirport', 'fromAirport')
+      .addSelect('entry.toAirport', 'toAirport')
+      .addSelect('entry.departureDate', 'departureDate')
+      .addSelect('entry.passengers', 'passengers')
+      .addSelect('entry.cabinClass', 'cabinClass')
+      .addSelect('COUNT(*)', 'searchCount')
+      .where('entry.createdAt >= :since', { since })
+      .andWhere('entry.departureDate >= :today', { today: new Date().toISOString().slice(0, 10) })
+      .groupBy('entry.fromAirport')
+      .addGroupBy('entry.toAirport')
+      .addGroupBy('entry.departureDate')
+      .addGroupBy('entry.passengers')
+      .addGroupBy('entry.cabinClass')
+      .orderBy('"searchCount"', 'DESC')
+      .limit(TOP_N)
+      .getRawMany<{
+        fromAirport: string;
+        toAirport: string;
+        departureDate: string;
+        passengers: number | string;
+        cabinClass: FlightSearchCriteria['travelClass'];
+        searchCount: string;
+      }>();
+
+    return rows.map((row) => ({
+      fromAirport: row.fromAirport,
+      toAirport: row.toAirport,
+      departureDate: row.departureDate,
+      passengers: Number(row.passengers),
+      cabinClass: row.cabinClass,
+      searchCount: Number(row.searchCount),
+    }));
+  }
+
+  /** Runs one warming pass immediately (also invoked by the cron tick). */
+  async runNow(): Promise<{ warmed: number; failed: number }> {
+    let warmed = 0;
+    let failed = 0;
+
+    let routes: FrequentRoute[];
+    try {
+      routes = await this.findFrequentRoutes();
+    } catch (err) {
+      logger.error('cacheWarmingJob: failed to load frequent routes', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return { warmed, failed };
+    }
+
+    for (const route of routes) {
+      const criteria: FlightSearchCriteria = {
+        from: route.fromAirport,
+        to: route.toAirport,
+        date: route.departureDate,
+        passengers: route.passengers,
+        travelClass: route.cabinClass,
+        sortBy: 'price',
+        pageSize: 20,
+      };
+
+      try {
+        // searchFlights() itself checks the cache first and writes through
+        // on a miss, so this both avoids duplicate work when already warm
+        // and populates the cache exactly the way a real request would.
+        await this.flightSearchService.searchFlights(criteria);
+        warmed += 1;
+      } catch (err) {
+        failed += 1;
+        logger.warn('cacheWarmingJob: failed to warm route', {
+          from: route.fromAirport,
+          to: route.toAirport,
+          date: route.departureDate,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    logger.info('cacheWarmingJob: pass complete', { warmed, failed, candidates: routes.length });
+    return { warmed, failed };
+  }
+
+  start(): void {
+    if (this.task) {
+      return;
+    }
+    this.task = cron.schedule(CRON_EXPRESSION, () => {
+      this.runNow().catch((err) => {
+        logger.error('cacheWarmingJob: unhandled error during scheduled run', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    });
+  }
+
+  stop(): void {
+    this.task?.stop();
+    this.task = null;
+  }
+}
+
+let sharedJob: CacheWarmingJob | null = null;
+
+export const initCacheWarmingCron = (): CacheWarmingJob => {
+  if (!sharedJob) {
+    sharedJob = new CacheWarmingJob();
+    sharedJob.start();
+  }
+  return sharedJob;
+};

--- a/packages/backend/src/jobs/flightStatusPollingJob.ts
+++ b/packages/backend/src/jobs/flightStatusPollingJob.ts
@@ -1,0 +1,108 @@
+/**
+ * Flight status polling job (issue #332) — periodically re-fetches status
+ * for every flight with at least one active alert, and notifies subscribers
+ * for anything that changed since the last known status.
+ *
+ * FlightStatusService.fetchStatuses() is still the mock/echo implementation
+ * described in its own docstring (no live airline status feed integrated
+ * yet), so this job's near-term value is as a catch-up/safety-net path — a
+ * status recorded through some other route (e.g. an ops tool calling
+ * recordStatus directly) still reaches subscribers even if /report was
+ * never called for it — and as the place a real provider gets plugged in
+ * later without touching callers.
+ */
+
+import cron from 'node-cron';
+import type { ScheduledTask } from 'node-cron';
+import FlightStatusAlert from '../models/FlightStatusAlert';
+import { FlightStatusService } from '../services/FlightStatusService';
+import { notifyFlightStatusChange } from '../services/flightStatusNotifier';
+import { logger } from '../utils/logger';
+
+const CRON_EXPRESSION = process.env.FLIGHT_STATUS_POLLING_CRON || '*/5 * * * *';
+
+export class FlightStatusPollingJob {
+  private readonly statusService: FlightStatusService;
+  private task: ScheduledTask | null = null;
+
+  constructor(statusService?: FlightStatusService) {
+    this.statusService = statusService ?? FlightStatusService.getInstance();
+  }
+
+  /** Runs one polling pass immediately (also invoked by the cron tick). */
+  async runNow(): Promise<{ polled: number; changed: number; notified: number }> {
+    let flightIds: string[];
+    try {
+      flightIds = await FlightStatusAlert.distinct('flightId', { isActive: true }).exec();
+    } catch (err) {
+      logger.error('flightStatusPollingJob: failed to load actively-followed flights', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return { polled: 0, changed: 0, notified: 0 };
+    }
+
+    if (flightIds.length === 0) {
+      return { polled: 0, changed: 0, notified: 0 };
+    }
+
+    let changed = 0;
+    let notified = 0;
+
+    let updates;
+    try {
+      updates = await this.statusService.fetchStatuses(flightIds);
+    } catch (err) {
+      logger.error('flightStatusPollingJob: fetchStatuses failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return { polled: flightIds.length, changed: 0, notified: 0 };
+    }
+
+    for (const update of updates) {
+      const { changed: didChange } = this.statusService.recordStatus(update);
+      if (!didChange) continue;
+
+      changed += 1;
+      try {
+        const { notifiedCount } = await notifyFlightStatusChange(update);
+        notified += notifiedCount;
+      } catch (err) {
+        logger.warn('flightStatusPollingJob: failed to notify subscribers', {
+          flightId: update.flightId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    logger.info('flightStatusPollingJob: pass complete', { polled: flightIds.length, changed, notified });
+    return { polled: flightIds.length, changed, notified };
+  }
+
+  start(): void {
+    if (this.task) {
+      return;
+    }
+    this.task = cron.schedule(CRON_EXPRESSION, () => {
+      this.runNow().catch((err) => {
+        logger.error('flightStatusPollingJob: unhandled error during scheduled run', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    });
+  }
+
+  stop(): void {
+    this.task?.stop();
+    this.task = null;
+  }
+}
+
+let sharedJob: FlightStatusPollingJob | null = null;
+
+export const initFlightStatusPollingCron = (): FlightStatusPollingJob => {
+  if (!sharedJob) {
+    sharedJob = new FlightStatusPollingJob();
+    sharedJob.start();
+  }
+  return sharedJob;
+};

--- a/packages/backend/src/services/FlightStatusService.ts
+++ b/packages/backend/src/services/FlightStatusService.ts
@@ -10,6 +10,20 @@ export interface FlightStatusUpdate {
   timestamp: Date;
 }
 
+export interface OnTimePerformance {
+  flightId: string;
+  sampleSize: number;
+  onTimeCount: number;
+  disruptedCount: number;
+  /** onTimeCount / sampleSize, or null when there's no recorded history yet. */
+  onTimeRate: number | null;
+}
+
+/** Transitions counted as a disruption for on-time performance purposes (issue #332). */
+const DISRUPTED_STATUSES: ReadonlySet<FlightStatusValue> = new Set(['delayed', 'cancelled']);
+
+const MAX_HISTORY_PER_FLIGHT = 50;
+
 /**
  * Tracks the last-known status for each flight in memory. Real-time gate/
  * delay/cancellation data has no live feed yet (issue #380), so this mirrors
@@ -20,6 +34,8 @@ export interface FlightStatusUpdate {
 export class FlightStatusService {
   private static instance: FlightStatusService;
   private readonly lastKnownStatus = new Map<string, FlightStatusUpdate>();
+  /** Bounded history of status *transitions* per flight, oldest first — used for on-time performance (issue #332). */
+  private readonly history = new Map<string, FlightStatusUpdate[]>();
 
   private constructor() {}
 
@@ -71,7 +87,41 @@ export class FlightStatusService {
   public recordStatus(update: FlightStatusUpdate): { changed: boolean; previous: FlightStatusUpdate | null } {
     const previous = this.lastKnownStatus.get(update.flightId) ?? null;
     this.lastKnownStatus.set(update.flightId, update);
-    return { changed: previous?.status !== update.status, previous };
+
+    const changed = previous?.status !== update.status;
+    if (changed) {
+      const entries = this.history.get(update.flightId) ?? [];
+      entries.push(update);
+      if (entries.length > MAX_HISTORY_PER_FLIGHT) {
+        entries.splice(0, entries.length - MAX_HISTORY_PER_FLIGHT);
+      }
+      this.history.set(update.flightId, entries);
+    }
+
+    return { changed, previous };
+  }
+
+  /**
+   * Historical on-time performance for a flight (issue #332), computed from
+   * recorded status *transitions* (not every poll — only actual changes).
+   * `delayed`/`cancelled` transitions count as disruptions; everything else
+   * (on_time, gate_changed, boarding, departed) counts as on-time. This is a
+   * simple deterministic count over in-memory history, not a statistical or
+   * predictive model, and resets on process restart since there's no
+   * persisted history table yet.
+   */
+  public getOnTimePerformance(flightId: string): OnTimePerformance {
+    const entries = this.history.get(flightId) ?? [];
+    const disruptedCount = entries.filter((entry) => DISRUPTED_STATUSES.has(entry.status)).length;
+    const sampleSize = entries.length;
+
+    return {
+      flightId,
+      sampleSize,
+      onTimeCount: sampleSize - disruptedCount,
+      disruptedCount,
+      onTimeRate: sampleSize > 0 ? (sampleSize - disruptedCount) / sampleSize : null,
+    };
   }
 
   private async mockApiCall(flightIds: string[]): Promise<FlightStatusUpdate[]> {

--- a/packages/backend/src/services/cacheService.ts
+++ b/packages/backend/src/services/cacheService.ts
@@ -1,0 +1,238 @@
+import Redis, { Cluster } from 'ioredis';
+import { recordCacheOperation } from './metrics';
+import { parseRedisClusterNodes, RedisClusterNode } from '../cache/redisClusterConfig';
+import { config } from '../config';
+import { logger } from '../utils/logger';
+
+/**
+ * General-purpose cache service (issue #335), distinct from
+ * `cache/searchCache.ts`'s flight-search-specific cache. Any route/service
+ * that needs read-through caching (not just flight search) can depend on
+ * this instead of hand-rolling its own Redis client. Supports Redis Cluster
+ * mode via REDIS_CLUSTER_NODES, with the same in-memory-fallback tolerance
+ * established by searchCache.ts.
+ */
+export interface CacheService {
+  get<T>(key: string): Promise<T | null>;
+  set<T>(key: string, value: T, ttlSeconds: number): Promise<void>;
+  del(key: string): Promise<void>;
+  invalidatePrefix(keyPrefix: string): Promise<void>;
+  /** Read-through helper: returns the cached value, or computes+caches it via fn on a miss. */
+  getOrSet<T>(key: string, ttlSeconds: number, fn: () => Promise<T>): Promise<T>;
+}
+
+interface MemoryEntry {
+  value: string;
+  expiresAt: number;
+}
+
+const getDurationSeconds = (start: bigint): number => {
+  return Number(process.hrtime.bigint() - start) / 1_000_000_000;
+};
+
+export class InMemoryCacheService implements CacheService {
+  private readonly store = new Map<string, MemoryEntry>();
+
+  constructor(private readonly cacheName: string) {}
+
+  async get<T>(key: string): Promise<T | null> {
+    const start = process.hrtime.bigint();
+    const entry = this.store.get(key);
+    if (!entry || entry.expiresAt <= Date.now()) {
+      if (entry) this.store.delete(key);
+      recordCacheOperation(this.cacheName, 'get', 'miss', getDurationSeconds(start));
+      return null;
+    }
+    recordCacheOperation(this.cacheName, 'get', 'hit', getDurationSeconds(start));
+    return JSON.parse(entry.value) as T;
+  }
+
+  async set<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
+    const start = process.hrtime.bigint();
+    this.store.set(key, { value: JSON.stringify(value), expiresAt: Date.now() + ttlSeconds * 1000 });
+    recordCacheOperation(this.cacheName, 'set', 'set', getDurationSeconds(start));
+  }
+
+  async del(key: string): Promise<void> {
+    const start = process.hrtime.bigint();
+    this.store.delete(key);
+    recordCacheOperation(this.cacheName, 'del', 'set', getDurationSeconds(start));
+  }
+
+  async invalidatePrefix(keyPrefix: string): Promise<void> {
+    const start = process.hrtime.bigint();
+    for (const key of this.store.keys()) {
+      if (key.startsWith(keyPrefix)) this.store.delete(key);
+    }
+    recordCacheOperation(this.cacheName, 'invalidate', 'set', getDurationSeconds(start));
+  }
+
+  async getOrSet<T>(key: string, ttlSeconds: number, fn: () => Promise<T>): Promise<T> {
+    return getOrSetImpl(this, key, ttlSeconds, fn);
+  }
+}
+
+class RedisCacheService implements CacheService {
+  private readonly memoryFallback: InMemoryCacheService;
+  private client: Redis | Cluster | null = null;
+  private disabled = false;
+
+  constructor(
+    private readonly redisUrl: string,
+    private readonly clusterNodes: RedisClusterNode[],
+    private readonly cacheName: string,
+  ) {
+    this.memoryFallback = new InMemoryCacheService(`${cacheName}-fallback`);
+  }
+
+  private async getClient(): Promise<Redis | Cluster | null> {
+    if (this.disabled) return null;
+    if (this.client) return this.client;
+
+    try {
+      const client: Redis | Cluster = this.clusterNodes.length > 0
+        ? new Redis.Cluster(this.clusterNodes, {
+          lazyConnect: true,
+          enableReadyCheck: true,
+          redisOptions: { maxRetriesPerRequest: 1 },
+        })
+        : new Redis(this.redisUrl, {
+          lazyConnect: true,
+          maxRetriesPerRequest: 1,
+          enableReadyCheck: true,
+        });
+      await client.connect();
+      this.client = client;
+      return client;
+    } catch (error) {
+      this.disabled = true;
+      logger.warn('cacheService: Redis unavailable, falling back to in-memory cache', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  async get<T>(key: string): Promise<T | null> {
+    const start = process.hrtime.bigint();
+    const client = await this.getClient();
+    if (!client) return this.memoryFallback.get<T>(key);
+
+    try {
+      const value = await client.get(key);
+      if (!value) {
+        recordCacheOperation(this.cacheName, 'get', 'miss', getDurationSeconds(start));
+        return null;
+      }
+      recordCacheOperation(this.cacheName, 'get', 'hit', getDurationSeconds(start));
+      return JSON.parse(value) as T;
+    } catch (_error) {
+      recordCacheOperation(this.cacheName, 'get', 'error', getDurationSeconds(start));
+      return this.memoryFallback.get<T>(key);
+    }
+  }
+
+  async set<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
+    const start = process.hrtime.bigint();
+    const client = await this.getClient();
+    if (!client) return this.memoryFallback.set(key, value, ttlSeconds);
+
+    try {
+      await client.set(key, JSON.stringify(value), 'EX', ttlSeconds);
+      recordCacheOperation(this.cacheName, 'set', 'set', getDurationSeconds(start));
+    } catch (_error) {
+      recordCacheOperation(this.cacheName, 'set', 'error', getDurationSeconds(start));
+      await this.memoryFallback.set(key, value, ttlSeconds);
+    }
+  }
+
+  async del(key: string): Promise<void> {
+    const start = process.hrtime.bigint();
+    const client = await this.getClient();
+    if (!client) return this.memoryFallback.del(key);
+
+    try {
+      await client.del(key);
+      recordCacheOperation(this.cacheName, 'del', 'set', getDurationSeconds(start));
+    } catch (_error) {
+      recordCacheOperation(this.cacheName, 'del', 'error', getDurationSeconds(start));
+      await this.memoryFallback.del(key);
+    }
+  }
+
+  /** SCAN + DEL rather than KEYS — non-blocking and cluster-safe (mirrors searchCache.ts). */
+  async invalidatePrefix(keyPrefix: string): Promise<void> {
+    const start = process.hrtime.bigint();
+    const client = await this.getClient();
+    if (!client) return this.memoryFallback.invalidatePrefix(keyPrefix);
+
+    try {
+      let cursor = '0';
+      const matched: string[] = [];
+      do {
+        const [nextCursor, keys] = await client.scan(cursor, 'MATCH', `${keyPrefix}*`, 'COUNT', 100);
+        cursor = nextCursor;
+        matched.push(...keys);
+      } while (cursor !== '0');
+
+      if (matched.length > 0) {
+        await client.del(...matched);
+      }
+      recordCacheOperation(this.cacheName, 'invalidate', 'set', getDurationSeconds(start));
+    } catch (_error) {
+      recordCacheOperation(this.cacheName, 'invalidate', 'error', getDurationSeconds(start));
+      await this.memoryFallback.invalidatePrefix(keyPrefix);
+    }
+  }
+
+  async getOrSet<T>(key: string, ttlSeconds: number, fn: () => Promise<T>): Promise<T> {
+    return getOrSetImpl(this, key, ttlSeconds, fn);
+  }
+}
+
+const getOrSetImpl = async <T>(
+  cache: CacheService,
+  key: string,
+  ttlSeconds: number,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  const cached = await cache.get<T>(key);
+  if (cached !== null) {
+    return cached;
+  }
+
+  const computed = await fn();
+  await cache.set(key, computed, ttlSeconds);
+  return computed;
+};
+
+export const createCacheService = (
+  redisUrl?: string,
+  clusterNodes: RedisClusterNode[] = [],
+  cacheName = 'app',
+): CacheService => {
+  if (!redisUrl && clusterNodes.length === 0) {
+    return new InMemoryCacheService(`${cacheName}-memory`);
+  }
+
+  return new RedisCacheService(redisUrl || '', clusterNodes, `${cacheName}-redis`);
+};
+
+let sharedCacheService: CacheService | null = null;
+
+/** Process-wide singleton, configured from env (REDIS_URL / REDIS_CLUSTER_NODES). */
+export const getCacheService = (): CacheService => {
+  if (!sharedCacheService) {
+    sharedCacheService = createCacheService(
+      config.redisUrl || undefined,
+      parseRedisClusterNodes(config.redisClusterNodes),
+      'app',
+    );
+  }
+  return sharedCacheService;
+};
+
+/** Test-only reset so each test file gets a fresh singleton. */
+export const __resetCacheServiceForTests = (): void => {
+  sharedCacheService = null;
+};

--- a/packages/backend/src/services/flightSearchService.ts
+++ b/packages/backend/src/services/flightSearchService.ts
@@ -1,4 +1,5 @@
 import { createSearchCache, SearchCache } from '../cache/searchCache';
+import { parseRedisClusterNodes } from '../cache/redisClusterConfig';
 import { config } from '../config';
 import { getPostgresPool } from '../db/postgres';
 import {
@@ -162,7 +163,11 @@ export const createDefaultFlightSearchService = (): FlightSearchService => {
     ? new PostgresFlightRepository(getPostgresPool())
     : new InMemoryFlightRepository();
 
-  const cache = createSearchCache(config.redisUrl || undefined, 'flight-search');
+  const cache = createSearchCache(
+    config.redisUrl || undefined,
+    'flight-search',
+    parseRedisClusterNodes(config.redisClusterNodes),
+  );
 
   return new FlightSearchService(repository, cache, config.flightSearchCacheTtlSeconds);
 };

--- a/packages/backend/src/services/flightStatusNotifier.ts
+++ b/packages/backend/src/services/flightStatusNotifier.ts
@@ -1,0 +1,92 @@
+import { logger } from '../utils/logger';
+import FlightStatusAlert from '../models/FlightStatusAlert';
+import { FlightStatusUpdate } from './FlightStatusService';
+import { NotificationService } from './NotificationService';
+import { getWebSocketServer, FlightStatus as WsFlightStatus } from '../websockets/server';
+
+/**
+ * Shared by the manual /flight-status/report endpoint and the automated
+ * polling job (issue #332) so a status change is notified/broadcast the
+ * same way regardless of how it was detected.
+ */
+
+/**
+ * Translates FlightStatusService's status vocabulary (matches the airline-
+ * status-feed shape) to the WebSocket layer's FlightStatus enum (issue
+ * #381's flight_status event) — the two were defined independently and use
+ * different casing/value sets.
+ */
+const STATUS_TO_WS: Record<FlightStatusUpdate['status'], WsFlightStatus> = {
+  on_time: 'SCHEDULED',
+  delayed: 'DELAYED',
+  cancelled: 'CANCELLED',
+  gate_changed: 'GATE_CHANGED',
+  boarding: 'BOARDING',
+  departed: 'LANDED',
+};
+
+export function buildAlertMessage(
+  flightId: string,
+  status: string,
+  details: { gate?: string; delayMinutes?: number; reason?: string },
+): string {
+  switch (status) {
+    case 'delayed':
+      return details.delayMinutes
+        ? `Flight ${flightId} is delayed by ${details.delayMinutes} minutes.`
+        : `Flight ${flightId} is delayed.`;
+    case 'cancelled':
+      return details.reason
+        ? `Flight ${flightId} has been cancelled: ${details.reason}`
+        : `Flight ${flightId} has been cancelled.`;
+    case 'gate_changed':
+      return details.gate
+        ? `Flight ${flightId}'s gate has changed to ${details.gate}.`
+        : `Flight ${flightId}'s gate has changed.`;
+    case 'boarding':
+      return `Flight ${flightId} is now boarding.`;
+    case 'departed':
+      return `Flight ${flightId} has departed.`;
+    default:
+      return `Flight ${flightId} status updated: ${status}.`;
+  }
+}
+
+/**
+ * Notifies every active subscriber of a flight status change and broadcasts
+ * it over WebSocket (both the free-text `alert` event and the typed
+ * `flight_status` event). Returns how many subscribers were notified.
+ */
+export async function notifyFlightStatusChange(update: FlightStatusUpdate): Promise<{ notifiedCount: number }> {
+  const { flightId, status, gate, delayMinutes, reason } = update;
+
+  const subscribers = await FlightStatusAlert.find({ flightId, isActive: true }).exec();
+  const notifier = NotificationService.getInstance();
+  let notifiedCount = 0;
+
+  for (const subscription of subscribers) {
+    const sent = await notifier.sendFlightStatusAlert(subscription.userId, flightId, status, {
+      gate,
+      delayMinutes,
+      reason,
+    });
+    if (sent) {
+      subscription.lastNotifiedAt = new Date();
+      subscription.lastStatus = status;
+      await subscription.save();
+      notifiedCount += 1;
+    }
+  }
+
+  try {
+    const ws = getWebSocketServer();
+    const message = buildAlertMessage(flightId, status, { gate, delayMinutes, reason });
+
+    ws.broadcastFlightAlert({ flightId, status, gate, delayMinutes, message });
+    ws.broadcastFlightStatus(flightId, STATUS_TO_WS[status], message);
+  } catch (_e) {
+    logger.warn('WebSocket server not ready, skipping flight status broadcast');
+  }
+
+  return { notifiedCount };
+}

--- a/packages/backend/tests/FlightStatusService.test.ts
+++ b/packages/backend/tests/FlightStatusService.test.ts
@@ -89,4 +89,49 @@ describe('FlightStatusService', () => {
     expect(result.status).toBe('gate_changed');
     expect(result.gate).toBe('B12');
   });
+
+  describe('getOnTimePerformance (issue #332)', () => {
+    it('returns a null rate for a flight with no recorded history', () => {
+      expect(service.getOnTimePerformance('flight-unknown')).toEqual({
+        flightId: 'flight-unknown',
+        sampleSize: 0,
+        onTimeCount: 0,
+        disruptedCount: 0,
+        onTimeRate: null,
+      });
+    });
+
+    it('counts delayed/cancelled transitions as disruptions and everything else as on-time', () => {
+      service.recordStatus({ flightId: 'flight-5', status: 'on_time', timestamp: new Date() });
+      service.recordStatus({ flightId: 'flight-5', status: 'delayed', timestamp: new Date() });
+      service.recordStatus({ flightId: 'flight-5', status: 'boarding', timestamp: new Date() });
+      service.recordStatus({ flightId: 'flight-5', status: 'departed', timestamp: new Date() });
+
+      const perf = service.getOnTimePerformance('flight-5');
+
+      expect(perf.sampleSize).toBe(4);
+      expect(perf.disruptedCount).toBe(1);
+      expect(perf.onTimeCount).toBe(3);
+      expect(perf.onTimeRate).toBe(0.75);
+    });
+
+    it('does not record a history entry when recordStatus reports no change', () => {
+      service.recordStatus({ flightId: 'flight-6', status: 'on_time', timestamp: new Date() });
+      service.recordStatus({ flightId: 'flight-6', status: 'on_time', timestamp: new Date() });
+
+      expect(service.getOnTimePerformance('flight-6').sampleSize).toBe(1);
+    });
+
+    it('caps history at the most recent 50 transitions per flight', () => {
+      const statuses: Array<'on_time' | 'delayed'> = [];
+      for (let i = 0; i < 60; i += 1) {
+        statuses.push(i % 2 === 0 ? 'on_time' : 'delayed');
+      }
+      statuses.forEach((status) => {
+        service.recordStatus({ flightId: 'flight-7', status, timestamp: new Date() });
+      });
+
+      expect(service.getOnTimePerformance('flight-7').sampleSize).toBe(50);
+    });
+  });
 });

--- a/packages/backend/tests/cache/redisClusterConfig.test.ts
+++ b/packages/backend/tests/cache/redisClusterConfig.test.ts
@@ -1,0 +1,37 @@
+import { parseRedisClusterNodes } from '../../src/cache/redisClusterConfig';
+
+describe('parseRedisClusterNodes (issue #335)', () => {
+  it('returns an empty array for undefined input', () => {
+    expect(parseRedisClusterNodes(undefined)).toEqual([]);
+  });
+
+  it('returns an empty array for an empty/whitespace string', () => {
+    expect(parseRedisClusterNodes('')).toEqual([]);
+    expect(parseRedisClusterNodes('   ')).toEqual([]);
+  });
+
+  it('parses a single host:port entry', () => {
+    expect(parseRedisClusterNodes('localhost:7000')).toEqual([{ host: 'localhost', port: 7000 }]);
+  });
+
+  it('parses multiple comma-separated entries and trims whitespace', () => {
+    expect(parseRedisClusterNodes(' localhost:7000 , localhost:7001,localhost:7002 ')).toEqual([
+      { host: 'localhost', port: 7000 },
+      { host: 'localhost', port: 7001 },
+      { host: 'localhost', port: 7002 },
+    ]);
+  });
+
+  it('skips entries with a missing or non-numeric port', () => {
+    expect(parseRedisClusterNodes('localhost:7000,localhost,localhost:abc,localhost:7001')).toEqual([
+      { host: 'localhost', port: 7000 },
+      { host: 'localhost', port: 7001 },
+    ]);
+  });
+
+  it('skips entries with a non-positive port', () => {
+    expect(parseRedisClusterNodes('localhost:0,localhost:-1,localhost:7000')).toEqual([
+      { host: 'localhost', port: 7000 },
+    ]);
+  });
+});

--- a/packages/backend/tests/jobs/cacheWarmingJob.test.ts
+++ b/packages/backend/tests/jobs/cacheWarmingJob.test.ts
@@ -1,0 +1,110 @@
+import { AppDataSource } from '../../src/db/dataSource';
+import { CacheWarmingJob } from '../../src/jobs/cacheWarmingJob';
+import { FlightSearchService } from '../../src/services/flightSearchService';
+
+describe('CacheWarmingJob (issue #335)', () => {
+  let queryBuilder: any;
+
+  beforeEach(() => {
+    queryBuilder = {
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      groupBy: jest.fn().mockReturnThis(),
+      addGroupBy: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([]),
+    };
+
+    jest.spyOn(AppDataSource, 'getRepository').mockReturnValue({
+      createQueryBuilder: jest.fn(() => queryBuilder),
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('warms the cache for every frequent route returned by the query', async () => {
+    queryBuilder.getRawMany.mockResolvedValue([
+      {
+        fromAirport: 'JFK',
+        toAirport: 'LHR',
+        departureDate: '2026-09-01',
+        passengers: '2',
+        cabinClass: 'economy',
+        searchCount: '15',
+      },
+      {
+        fromAirport: 'LAX',
+        toAirport: 'CDG',
+        departureDate: '2026-09-05',
+        passengers: '1',
+        cabinClass: 'business',
+        searchCount: '8',
+      },
+    ]);
+
+    const searchFlights = jest.fn().mockResolvedValue({ data: [], pagination: { has_more: false, next_cursor: null, page_size: 20 } });
+    const fakeService = { searchFlights } as unknown as FlightSearchService;
+
+    const job = new CacheWarmingJob(fakeService);
+    const result = await job.runNow();
+
+    expect(result).toEqual({ warmed: 2, failed: 0 });
+    expect(searchFlights).toHaveBeenCalledTimes(2);
+    expect(searchFlights).toHaveBeenNthCalledWith(1, {
+      from: 'JFK',
+      to: 'LHR',
+      date: '2026-09-01',
+      passengers: 2,
+      travelClass: 'economy',
+      sortBy: 'price',
+      pageSize: 20,
+    });
+  });
+
+  it('counts a failed warm without aborting the remaining routes', async () => {
+    queryBuilder.getRawMany.mockResolvedValue([
+      { fromAirport: 'JFK', toAirport: 'LHR', departureDate: '2026-09-01', passengers: '1', cabinClass: 'economy', searchCount: '5' },
+      { fromAirport: 'LAX', toAirport: 'CDG', departureDate: '2026-09-05', passengers: '1', cabinClass: 'economy', searchCount: '3' },
+    ]);
+
+    const searchFlights = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('provider down'))
+      .mockResolvedValueOnce({ data: [], pagination: { has_more: false, next_cursor: null, page_size: 20 } });
+    const fakeService = { searchFlights } as unknown as FlightSearchService;
+
+    const job = new CacheWarmingJob(fakeService);
+    const result = await job.runNow();
+
+    expect(result).toEqual({ warmed: 1, failed: 1 });
+  });
+
+  it('returns zero counts and does not throw when the query fails', async () => {
+    queryBuilder.getRawMany.mockRejectedValue(new Error('db unavailable'));
+
+    const searchFlights = jest.fn();
+    const fakeService = { searchFlights } as unknown as FlightSearchService;
+
+    const job = new CacheWarmingJob(fakeService);
+    const result = await job.runNow();
+
+    expect(result).toEqual({ warmed: 0, failed: 0 });
+    expect(searchFlights).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when there are no frequent routes', async () => {
+    const searchFlights = jest.fn();
+    const fakeService = { searchFlights } as unknown as FlightSearchService;
+
+    const job = new CacheWarmingJob(fakeService);
+    const result = await job.runNow();
+
+    expect(result).toEqual({ warmed: 0, failed: 0 });
+    expect(searchFlights).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/tests/jobs/flightStatusPollingJob.test.ts
+++ b/packages/backend/tests/jobs/flightStatusPollingJob.test.ts
@@ -1,0 +1,97 @@
+jest.mock('../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const distinctExecMock = jest.fn();
+jest.mock('../../src/models/FlightStatusAlert', () => ({
+  __esModule: true,
+  default: {
+    distinct: jest.fn(() => ({ exec: distinctExecMock })),
+  },
+}));
+
+const notifyFlightStatusChangeMock = jest.fn();
+jest.mock('../../src/services/flightStatusNotifier', () => ({
+  notifyFlightStatusChange: (...args: unknown[]) => notifyFlightStatusChangeMock(...args),
+}));
+
+import { FlightStatusPollingJob } from '../../src/jobs/flightStatusPollingJob';
+import { FlightStatusService } from '../../src/services/FlightStatusService';
+
+describe('FlightStatusPollingJob (issue #332)', () => {
+  let statusService: FlightStatusService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require('../../src/services/FlightStatusService');
+    statusService = mod.FlightStatusService.getInstance();
+    notifyFlightStatusChangeMock.mockResolvedValue({ notifiedCount: 1 });
+  });
+
+  it('is a no-op when nothing has an active alert', async () => {
+    distinctExecMock.mockResolvedValue([]);
+
+    const job = new FlightStatusPollingJob(statusService);
+    const result = await job.runNow();
+
+    expect(result).toEqual({ polled: 0, changed: 0, notified: 0 });
+    expect(notifyFlightStatusChangeMock).not.toHaveBeenCalled();
+  });
+
+  it('notifies for a flight whose status changed since the last poll', async () => {
+    distinctExecMock.mockResolvedValue(['FL1']);
+    statusService.recordStatus({ flightId: 'FL1', status: 'on_time', timestamp: new Date() });
+    jest
+      .spyOn(statusService, 'fetchStatuses')
+      .mockResolvedValue([{ flightId: 'FL1', status: 'delayed', delayMinutes: 15, timestamp: new Date() }]);
+
+    const job = new FlightStatusPollingJob(statusService);
+    const result = await job.runNow();
+
+    expect(result).toEqual({ polled: 1, changed: 1, notified: 1 });
+    expect(notifyFlightStatusChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ flightId: 'FL1', status: 'delayed' }),
+    );
+  });
+
+  it('does not notify for a flight whose status is unchanged', async () => {
+    distinctExecMock.mockResolvedValue(['FL1']);
+    statusService.recordStatus({ flightId: 'FL1', status: 'on_time', timestamp: new Date() });
+    jest
+      .spyOn(statusService, 'fetchStatuses')
+      .mockResolvedValue([{ flightId: 'FL1', status: 'on_time', timestamp: new Date() }]);
+
+    const job = new FlightStatusPollingJob(statusService);
+    const result = await job.runNow();
+
+    expect(result).toEqual({ polled: 1, changed: 0, notified: 0 });
+    expect(notifyFlightStatusChangeMock).not.toHaveBeenCalled();
+  });
+
+  it('continues to the next flight when notifying one fails', async () => {
+    distinctExecMock.mockResolvedValue(['FL1', 'FL2']);
+    jest.spyOn(statusService, 'fetchStatuses').mockResolvedValue([
+      { flightId: 'FL1', status: 'delayed', timestamp: new Date() },
+      { flightId: 'FL2', status: 'cancelled', timestamp: new Date() },
+    ]);
+    notifyFlightStatusChangeMock
+      .mockRejectedValueOnce(new Error('notify failed'))
+      .mockResolvedValueOnce({ notifiedCount: 3 });
+
+    const job = new FlightStatusPollingJob(statusService);
+    const result = await job.runNow();
+
+    expect(result).toEqual({ polled: 2, changed: 2, notified: 3 });
+  });
+
+  it('returns zero counts without throwing when loading active flights fails', async () => {
+    distinctExecMock.mockRejectedValue(new Error('db down'));
+
+    const job = new FlightStatusPollingJob(statusService);
+    const result = await job.runNow();
+
+    expect(result).toEqual({ polled: 0, changed: 0, notified: 0 });
+  });
+});

--- a/packages/backend/tests/services/cacheService.test.ts
+++ b/packages/backend/tests/services/cacheService.test.ts
@@ -1,0 +1,92 @@
+import {
+  InMemoryCacheService,
+  createCacheService,
+  getCacheService,
+  __resetCacheServiceForTests,
+} from '../../src/services/cacheService';
+
+describe('InMemoryCacheService (issue #335)', () => {
+  it('returns null on a miss and the stored value on a hit', async () => {
+    const cache = new InMemoryCacheService('test');
+    expect(await cache.get('missing')) .toBeNull();
+
+    await cache.set('key1', { a: 1 }, 60);
+    expect(await cache.get('key1')).toEqual({ a: 1 });
+  });
+
+  it('expires entries after their TTL', async () => {
+    const cache = new InMemoryCacheService('test');
+    await cache.set('key1', 'value', -1);
+    expect(await cache.get('key1')).toBeNull();
+  });
+
+  it('deletes a single key via del', async () => {
+    const cache = new InMemoryCacheService('test');
+    await cache.set('key1', 'value', 60);
+    await cache.del('key1');
+    expect(await cache.get('key1')).toBeNull();
+  });
+
+  it('invalidates only keys matching a prefix', async () => {
+    const cache = new InMemoryCacheService('test');
+    await cache.set('flights:a', 1, 60);
+    await cache.set('flights:b', 2, 60);
+    await cache.set('bookings:a', 3, 60);
+
+    await cache.invalidatePrefix('flights:');
+
+    expect(await cache.get('flights:a')).toBeNull();
+    expect(await cache.get('flights:b')).toBeNull();
+    expect(await cache.get('bookings:a')).toBe(3);
+  });
+
+  describe('getOrSet', () => {
+    it('computes and caches the value on a miss', async () => {
+      const cache = new InMemoryCacheService('test');
+      const fn = jest.fn().mockResolvedValue('computed');
+
+      const result = await cache.getOrSet('key1', 60, fn);
+
+      expect(result).toBe('computed');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the cached value without recomputing on a hit', async () => {
+      const cache = new InMemoryCacheService('test');
+      const fn = jest.fn().mockResolvedValue('computed');
+
+      await cache.getOrSet('key1', 60, fn);
+      const second = await cache.getOrSet('key1', 60, fn);
+
+      expect(second).toBe('computed');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('createCacheService factory (issue #335)', () => {
+  it('produces an in-memory cache when no redisUrl or clusterNodes are given', async () => {
+    const cache = createCacheService(undefined, [], 'test');
+    await cache.set('key1', 'value', 60);
+    expect(await cache.get('key1')).toBe('value');
+  });
+});
+
+describe('getCacheService singleton (issue #335)', () => {
+  afterEach(() => {
+    __resetCacheServiceForTests();
+  });
+
+  it('returns the same instance on repeated calls', () => {
+    const first = getCacheService();
+    const second = getCacheService();
+    expect(first).toBe(second);
+  });
+
+  it('returns a fresh instance after a test reset', () => {
+    const first = getCacheService();
+    __resetCacheServiceForTests();
+    const second = getCacheService();
+    expect(first).not.toBe(second);
+  });
+});

--- a/packages/backend/tests/services/flightStatusNotifier.test.ts
+++ b/packages/backend/tests/services/flightStatusNotifier.test.ts
@@ -1,0 +1,127 @@
+jest.mock('../../src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const findExecMock = jest.fn();
+jest.mock('../../src/models/FlightStatusAlert', () => ({
+  __esModule: true,
+  default: {
+    find: jest.fn(() => ({ exec: findExecMock })),
+  },
+}));
+
+const sendFlightStatusAlertMock = jest.fn();
+jest.mock('../../src/services/NotificationService', () => ({
+  NotificationService: {
+    getInstance: () => ({ sendFlightStatusAlert: sendFlightStatusAlertMock }),
+  },
+}));
+
+const broadcastFlightAlertMock = jest.fn();
+const broadcastFlightStatusMock = jest.fn();
+jest.mock('../../src/websockets/server', () => ({
+  getWebSocketServer: jest.fn(() => ({
+    broadcastFlightAlert: broadcastFlightAlertMock,
+    broadcastFlightStatus: broadcastFlightStatusMock,
+  })),
+}));
+
+import { notifyFlightStatusChange, buildAlertMessage } from '../../src/services/flightStatusNotifier';
+import { getWebSocketServer } from '../../src/websockets/server';
+
+describe('notifyFlightStatusChange (issue #332)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('notifies every active subscriber and updates their lastStatus/lastNotifiedAt', async () => {
+    const subscription1 = { userId: 'user-1', save: jest.fn() };
+    const subscription2 = { userId: 'user-2', save: jest.fn() };
+    findExecMock.mockResolvedValue([subscription1, subscription2]);
+    sendFlightStatusAlertMock.mockResolvedValue(true);
+
+    const { notifiedCount } = await notifyFlightStatusChange({
+      flightId: 'FL1',
+      status: 'delayed',
+      delayMinutes: 20,
+      timestamp: new Date(),
+    });
+
+    expect(notifiedCount).toBe(2);
+    expect(subscription1.save).toHaveBeenCalled();
+    expect(subscription1).toMatchObject({ lastStatus: 'delayed' });
+    expect(sendFlightStatusAlertMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not count a subscriber whose notification failed to send', async () => {
+    const subscription = { userId: 'user-1', save: jest.fn() };
+    findExecMock.mockResolvedValue([subscription]);
+    sendFlightStatusAlertMock.mockResolvedValue(false);
+
+    const { notifiedCount } = await notifyFlightStatusChange({
+      flightId: 'FL1',
+      status: 'cancelled',
+      timestamp: new Date(),
+    });
+
+    expect(notifiedCount).toBe(0);
+    expect(subscription.save).not.toHaveBeenCalled();
+  });
+
+  it('broadcasts both the free-text alert and the typed flight_status event', async () => {
+    findExecMock.mockResolvedValue([]);
+
+    await notifyFlightStatusChange({
+      flightId: 'FL1',
+      status: 'gate_changed',
+      gate: 'B12',
+      timestamp: new Date(),
+    });
+
+    expect(broadcastFlightAlertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ flightId: 'FL1', status: 'gate_changed', gate: 'B12' }),
+    );
+    expect(broadcastFlightStatusMock).toHaveBeenCalledWith('FL1', 'GATE_CHANGED', expect.any(String));
+  });
+
+  it('maps every FlightStatusService status to a valid WebSocket FlightStatus value', async () => {
+    findExecMock.mockResolvedValue([]);
+    const cases: Array<[string, string]> = [
+      ['on_time', 'SCHEDULED'],
+      ['delayed', 'DELAYED'],
+      ['cancelled', 'CANCELLED'],
+      ['gate_changed', 'GATE_CHANGED'],
+      ['boarding', 'BOARDING'],
+      ['departed', 'LANDED'],
+    ];
+
+    for (const [status, expectedWs] of cases) {
+      broadcastFlightStatusMock.mockClear();
+      await notifyFlightStatusChange({ flightId: 'FL1', status: status as any, timestamp: new Date() });
+      expect(broadcastFlightStatusMock).toHaveBeenCalledWith('FL1', expectedWs, expect.any(String));
+    }
+  });
+
+  it('does not throw when the WebSocket server is not initialized yet', async () => {
+    findExecMock.mockResolvedValue([]);
+    (getWebSocketServer as jest.Mock).mockImplementationOnce(() => {
+      throw new Error('WebSocket Server not initialized');
+    });
+
+    await expect(
+      notifyFlightStatusChange({ flightId: 'FL1', status: 'delayed', timestamp: new Date() }),
+    ).resolves.toEqual({ notifiedCount: 0 });
+  });
+});
+
+describe('buildAlertMessage (issue #332)', () => {
+  it('builds a delay message with minutes when provided', () => {
+    expect(buildAlertMessage('FL1', 'delayed', { delayMinutes: 45 })).toBe(
+      'Flight FL1 is delayed by 45 minutes.',
+    );
+  });
+
+  it('builds a generic message for an unrecognized status', () => {
+    expect(buildAlertMessage('FL1', 'unknown_status', {})).toBe('Flight FL1 status updated: unknown_status.');
+  });
+});

--- a/packages/client/app/dashboard/page.tsx
+++ b/packages/client/app/dashboard/page.tsx
@@ -34,6 +34,8 @@ import { useOffline } from "@/components/offline-provider"
 import { OfflineItineraryView } from "@/components/offline-itinerary-view"
 // NEW: real-time flight status alerts (delays, cancellations, gate changes)
 import { FlightStatusBanner } from "@/components/flight-status/FlightStatusBanner"
+// NEW: flight-following widget with live status + on-time performance (issue #332)
+import { FollowedFlightsCard } from "@/components/flight-status/FollowedFlightsCard"
 
 // Mock user data
 const mockUser = {
@@ -302,6 +304,10 @@ export default function DashboardPage() {
 
           <div className="mb-8">
             <FlightStatusBanner />
+          </div>
+
+          <div className="mb-8">
+            <FollowedFlightsCard />
           </div>
 
         {/* Stats Overview */}

--- a/packages/client/app/global-error.tsx
+++ b/packages/client/app/global-error.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+/**
+ * Root error boundary (issue #334) — Next.js only invokes this for errors
+ * thrown during rendering of the root layout itself, which is why it must
+ * render its own <html>/<body> rather than relying on app/layout.tsx (that
+ * may be what failed). Captures the crash to Sentry and offers the report
+ * dialog so the user can attach what they were doing.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    const eventId = Sentry.captureException(error);
+
+    Sentry.showReportDialog({
+      eventId,
+      title: "Something went wrong",
+      subtitle: "Our team has been notified. Let us know what happened, if you'd like.",
+    });
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body>
+        <div
+          style={{
+            display: "flex",
+            minHeight: "100vh",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "1rem",
+            padding: "2rem",
+            textAlign: "center",
+            fontFamily: "system-ui, sans-serif",
+          }}
+        >
+          <h1 style={{ fontSize: "1.5rem", fontWeight: 600 }}>Something went wrong</h1>
+          <p style={{ color: "#64748b", maxWidth: "32rem" }}>
+            We&apos;ve been notified and are looking into it. You can try again, or send us more
+            details using the report dialog.
+          </p>
+          <button
+            onClick={() => reset()}
+            style={{
+              padding: "0.5rem 1.25rem",
+              borderRadius: "0.375rem",
+              border: "none",
+              background: "#0f172a",
+              color: "#fff",
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/packages/client/components/flight-status/FollowedFlightsCard.tsx
+++ b/packages/client/components/flight-status/FollowedFlightsCard.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { PlaneTakeoff, X } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useFlightStatusAlerts } from '@/hooks/useFlightStatusAlerts';
+
+interface OnTimePerformance {
+  flightId: string;
+  sampleSize: number;
+  onTimeCount: number;
+  disruptedCount: number;
+  onTimeRate: number | null;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  on_time: 'On time',
+  delayed: 'Delayed',
+  cancelled: 'Cancelled',
+  gate_changed: 'Gate changed',
+  boarding: 'Boarding',
+  departed: 'Departed',
+};
+
+const DISRUPTED_STATUSES = new Set(['delayed', 'cancelled']);
+
+async function fetchOnTimePerformance(flightId: string): Promise<OnTimePerformance | null> {
+  try {
+    const res = await fetch(`/api/v1/flight-status/${encodeURIComponent(flightId)}/performance`);
+    if (!res.ok) return null;
+    const body = await res.json();
+    return body.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * "Flight following" dashboard widget (issue #332): lists the flights the
+ * user has an active real-time status subscription for (see
+ * useFlightStatusAlerts, wired to the flight_status WebSocket event in
+ * issue #333), each with its live status and historical on-time rate.
+ */
+export function FollowedFlightsCard() {
+  const { alerts, isLoading, unsubscribe } = useFlightStatusAlerts();
+  const [performance, setPerformance] = useState<Record<string, OnTimePerformance>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+
+    Promise.all(alerts.map((alert) => fetchOnTimePerformance(alert.flightId))).then((results) => {
+      if (cancelled) return;
+      setPerformance((prev) => {
+        const next = { ...prev };
+        results.forEach((perf, i) => {
+          if (perf) next[alerts[i].flightId] = perf;
+        });
+        return next;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [alerts.map((a) => a.flightId).join(',')]);
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (alerts.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <PlaneTakeoff className="h-5 w-5" />
+            Followed Flights
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            You&apos;re not following any flights yet. Subscribe to a flight from its status page to get
+            real-time delay and gate-change alerts here.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <PlaneTakeoff className="h-5 w-5" />
+          Followed Flights
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {alerts.map((alert) => {
+          const perf = performance[alert.flightId];
+          const status = alert.lastStatus;
+          const disrupted = status ? DISRUPTED_STATUSES.has(status) : false;
+
+          return (
+            <div
+              key={alert.id}
+              className="flex items-center justify-between rounded-md border border-border p-3"
+            >
+              <div>
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">{alert.flightId}</span>
+                  {status && (
+                    <Badge variant={disrupted ? 'destructive' : 'secondary'}>
+                      {STATUS_LABELS[status] ?? status}
+                    </Badge>
+                  )}
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {perf && perf.sampleSize > 0
+                    ? `On-time ${Math.round((perf.onTimeRate ?? 0) * 100)}% (${perf.sampleSize} recorded change${perf.sampleSize === 1 ? '' : 's'})`
+                    : 'No on-time performance history yet'}
+                </p>
+              </div>
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-label={`Stop following flight ${alert.flightId}`}
+                onClick={() => unsubscribe(alert.id).catch(() => undefined)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/client/hooks/use-socket-events.ts
+++ b/packages/client/hooks/use-socket-events.ts
@@ -21,6 +21,16 @@ export interface FlightAlertEvent {
   timestamp?: Date;
 }
 
+export type FlightStatusValue = 'SCHEDULED' | 'DELAYED' | 'GATE_CHANGED' | 'BOARDING' | 'CANCELLED' | 'LANDED';
+
+/** Typed flight status change (issue #333) — mirrors the server's FlightStatusPayload emitted on the "flight_status" event. */
+export interface FlightStatusEvent {
+  flightId: string;
+  status: FlightStatusValue;
+  detail?: string;
+  timestamp?: Date;
+}
+
 interface UseSocketEventsOptions {
   /** Filter contract events to only those matching this wallet address. */
   walletAddress?: string;
@@ -31,11 +41,13 @@ interface UseSocketEventsOptions {
   onBookingStatus?: (data: { bookingId: string; status: string; timestamp: Date }) => void;
   /** Flight status changes: delays, cancellations, gate changes (#380). */
   onFlightAlert?: (data: FlightAlertEvent) => void;
+  /** Typed flight status transitions (issue #333) — distinct from onFlightAlert's free-text message. */
+  onFlightStatus?: (data: FlightStatusEvent) => void;
 }
 
 export function useSocketEvents(options: UseSocketEventsOptions = {}) {
   const { manager } = useSocket();
-  const { walletAddress, eventTypes, onContractEvent, onPriceUpdate, onBookingStatus, onFlightAlert } = options;
+  const { walletAddress, eventTypes, onContractEvent, onPriceUpdate, onBookingStatus, onFlightAlert, onFlightStatus } = options;
 
   const handleContractEvent = useCallback(
     (event: ContractEvent) => {
@@ -63,11 +75,16 @@ export function useSocketEvents(options: UseSocketEventsOptions = {}) {
       console.debug('alert', d);
       onFlightAlert?.(d);
     };
+    const onFlightStatusChange = (d: any) => {
+      console.debug('flight_status', d);
+      onFlightStatus?.(d);
+    };
 
     manager.on('priceUpdate', onPrice);
     manager.on('booking_status', onBooking);
     manager.on('contract_event', onContract);
     manager.on('alert', onAlert);
+    manager.on('flight_status', onFlightStatusChange);
 
     // Subscribe to address-specific room for targeted contract event delivery.
     if (walletAddress) {
@@ -79,10 +96,11 @@ export function useSocketEvents(options: UseSocketEventsOptions = {}) {
       manager.off('booking_status', onBooking);
       manager.off('contract_event', onContract);
       manager.off('alert', onAlert);
+      manager.off('flight_status', onFlightStatusChange);
 
       if (walletAddress) {
         manager.emit('unsubscribe_address', walletAddress);
       }
     };
-  }, [manager, walletAddress, handleContractEvent, onPriceUpdate, onBookingStatus, onFlightAlert]);
+  }, [manager, walletAddress, handleContractEvent, onPriceUpdate, onBookingStatus, onFlightAlert, onFlightStatus]);
 }

--- a/packages/client/hooks/useFlightStatusAlerts.ts
+++ b/packages/client/hooks/useFlightStatusAlerts.ts
@@ -1,7 +1,9 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useToast } from '@/hooks/use-toast';
+import { useSocket } from '@/components/socket/SocketProvider';
+import { useSocketEvents, type FlightStatusEvent } from '@/hooks/use-socket-events';
 
 export interface FlightStatusAlert {
   id: string;
@@ -112,6 +114,65 @@ export function useFlightStatusAlerts() {
   useEffect(() => {
     fetchAlerts();
   }, [fetchAlerts]);
+
+  const { manager } = useSocket();
+  const subscribedFlightIds = useRef<Set<string>>(new Set());
+
+  // Real-time delivery over WebSocket (issue #333): join the room for every
+  // flight the user has an active alert on, so the server's
+  // broadcastFlightStatus() reaches this client immediately instead of only
+  // being visible on the next manual fetchAlerts() call.
+  useEffect(() => {
+    const activeFlightIds = new Set(alerts.filter((a) => a.isActive).map((a) => a.flightId));
+
+    activeFlightIds.forEach((flightId) => {
+      if (!subscribedFlightIds.current.has(flightId)) {
+        manager.subscribeFlight(flightId);
+      }
+    });
+    subscribedFlightIds.current.forEach((flightId) => {
+      if (!activeFlightIds.has(flightId)) {
+        manager.unsubscribeFlight(flightId);
+      }
+    });
+
+    subscribedFlightIds.current = activeFlightIds;
+  }, [alerts, manager]);
+
+  useEffect(() => {
+    return () => {
+      subscribedFlightIds.current.forEach((flightId) => manager.unsubscribeFlight(flightId));
+      subscribedFlightIds.current.clear();
+    };
+  }, [manager]);
+
+  const handleFlightStatus = useCallback(
+    (data: FlightStatusEvent) => {
+      let matched = false;
+
+      setAlerts((prev) =>
+        prev.map((alert) => {
+          if (alert.flightId !== data.flightId || !alert.isActive) return alert;
+          matched = true;
+          return {
+            ...alert,
+            lastStatus: data.status,
+            lastNotifiedAt: (data.timestamp ? new Date(data.timestamp) : new Date()).toISOString(),
+          };
+        }),
+      );
+
+      if (matched) {
+        toast({
+          title: `Flight ${data.flightId} status update`,
+          description: data.detail ? `${data.status}: ${data.detail}` : data.status,
+        });
+      }
+    },
+    [toast],
+  );
+
+  useSocketEvents({ onFlightStatus: handleFlightStatus });
 
   return {
     alerts,

--- a/packages/client/lib/socket.ts
+++ b/packages/client/lib/socket.ts
@@ -10,6 +10,13 @@ type FlightAlert = {
   delayMinutes?: number;
   timestamp?: Date;
 };
+type FlightStatusValue = 'SCHEDULED' | 'DELAYED' | 'GATE_CHANGED' | 'BOARDING' | 'CANCELLED' | 'LANDED';
+type FlightStatusChange = {
+  flightId: string;
+  status: FlightStatusValue;
+  detail?: string;
+  timestamp: Date;
+};
 
 class SocketManager {
   private socket: Socket | null = null;
@@ -76,6 +83,20 @@ class SocketManager {
   onFlightAlert(fn: (data: FlightAlert) => void) {
     // server emits "alert" (flight status changes: delays, cancellations, gate changes)
     this.socket?.on('alert', fn);
+  }
+
+  /** Server emits "flight_status" (issue #333) — the typed status enum + optional detail, distinct from "alert"'s free-text message. */
+  onFlightStatus(fn: (data: FlightStatusChange) => void) {
+    this.socket?.on('flight_status', fn);
+  }
+
+  /** Joins the `flight:<flightId>` room so flight_status/alert/priceUpdate events for it are delivered to this socket (issue #333). */
+  subscribeFlight(flightId: string) {
+    this.socket?.emit('subscribe', flightId);
+  }
+
+  unsubscribeFlight(flightId: string) {
+    this.socket?.emit('unsubscribe', flightId);
   }
 
   on(event: string, fn: (...args: any[]) => void) {

--- a/packages/client/sentry.client.config.ts
+++ b/packages/client/sentry.client.config.ts
@@ -14,4 +14,15 @@ Sentry.init({
   enabled: Boolean(process.env.NEXT_PUBLIC_SENTRY_DSN),
   // PII/secret scrubbing (#382) — see scrubEvent for the field list.
   beforeSend: scrubEvent,
+  // User feedback widget (issue #334): a "Report a Bug" tab users can open
+  // any time, plus an automatic prompt after a captured crash. Uses
+  // Sentry's own screenshot/attachment pipeline — no custom widget UI to
+  // build or maintain.
+  integrations: [
+    Sentry.feedbackIntegration({
+      colorScheme: "system",
+      showBranding: false,
+      autoInject: true,
+    }),
+  ],
 });

--- a/packages/client/tests/errors/global-error.test.tsx
+++ b/packages/client/tests/errors/global-error.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import * as Sentry from '@sentry/nextjs'
+import GlobalError from '@/app/global-error'
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(() => 'event-id-123'),
+  showReportDialog: jest.fn(),
+}))
+
+describe('GlobalError (issue #334)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('reports the crash to Sentry and opens the feedback dialog', () => {
+    const error = Object.assign(new Error('boom'), { digest: 'abc123' })
+    render(<GlobalError error={error} reset={jest.fn()} />)
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error)
+    expect(Sentry.showReportDialog).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: 'event-id-123' }),
+    )
+  })
+
+  it('renders a fallback message and calls reset when the retry button is clicked', () => {
+    const reset = jest.fn()
+    render(<GlobalError error={new Error('boom')} reset={reset} />)
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Try again'))
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-reports when a new error is passed in', () => {
+    const error1 = new Error('first')
+    const { rerender } = render(<GlobalError error={error1} reset={jest.fn()} />)
+    expect(Sentry.captureException).toHaveBeenCalledTimes(1)
+
+    const error2 = new Error('second')
+    rerender(<GlobalError error={error2} reset={jest.fn()} />)
+    expect(Sentry.captureException).toHaveBeenCalledTimes(2)
+    expect(Sentry.captureException).toHaveBeenLastCalledWith(error2)
+  })
+})

--- a/packages/client/tests/errors/sentry-client-config.test.ts
+++ b/packages/client/tests/errors/sentry-client-config.test.ts
@@ -1,0 +1,34 @@
+const initMock = jest.fn()
+const feedbackIntegrationMock = jest.fn(() => ({ name: 'Feedback' }))
+
+jest.mock('@sentry/nextjs', () => ({
+  init: (...args: unknown[]) => initMock(...args),
+  feedbackIntegration: (...args: unknown[]) => feedbackIntegrationMock(...args),
+}))
+
+describe('sentry.client.config (issue #334 feedback widget)', () => {
+  const originalDsn = process.env.NEXT_PUBLIC_SENTRY_DSN
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.resetModules()
+    process.env.NEXT_PUBLIC_SENTRY_DSN = 'https://example.ingest.sentry.io/1'
+  })
+
+  afterAll(() => {
+    process.env.NEXT_PUBLIC_SENTRY_DSN = originalDsn
+  })
+
+  it('registers the feedback widget integration with auto-inject enabled', async () => {
+    await import('../../sentry.client.config')
+
+    expect(feedbackIntegrationMock).toHaveBeenCalledWith(
+      expect.objectContaining({ autoInject: true }),
+    )
+    expect(initMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrations: [{ name: 'Feedback' }],
+      }),
+    )
+  })
+})

--- a/packages/client/tests/flight-status/FollowedFlightsCard.test.tsx
+++ b/packages/client/tests/flight-status/FollowedFlightsCard.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { FollowedFlightsCard } from '@/components/flight-status/FollowedFlightsCard'
+
+const unsubscribeMock = jest.fn().mockResolvedValue(undefined)
+let mockAlerts: any[] = []
+let mockIsLoading = false
+
+jest.mock('@/hooks/useFlightStatusAlerts', () => ({
+  useFlightStatusAlerts: () => ({
+    alerts: mockAlerts,
+    isLoading: mockIsLoading,
+    unsubscribe: unsubscribeMock,
+  }),
+}))
+
+describe('FollowedFlightsCard (issue #332)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockAlerts = []
+    mockIsLoading = false
+    global.fetch = jest.fn(async () =>
+      new Response(
+        JSON.stringify({ data: { flightId: 'FL1', sampleSize: 4, onTimeCount: 3, disruptedCount: 1, onTimeRate: 0.75 } }),
+        { status: 200 },
+      ),
+    ) as any
+  })
+
+  it('renders nothing while alerts are loading', () => {
+    mockIsLoading = true
+    const { container } = render(<FollowedFlightsCard />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows an empty state when there are no followed flights', () => {
+    render(<FollowedFlightsCard />)
+    expect(screen.getByText(/not following any flights/i)).toBeInTheDocument()
+  })
+
+  it('lists each followed flight with its status badge and on-time performance', async () => {
+    mockAlerts = [
+      { id: 'a1', userId: 'u1', flightId: 'FL1', isActive: true, createdAt: new Date().toISOString(), lastStatus: 'delayed' },
+    ]
+
+    render(<FollowedFlightsCard />)
+
+    expect(screen.getByText('FL1')).toBeInTheDocument()
+    expect(screen.getByText('Delayed')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText(/On-time 75%/)).toBeInTheDocument()
+    })
+  })
+
+  it('calls unsubscribe with the alert id when the remove button is clicked', async () => {
+    mockAlerts = [
+      { id: 'a1', userId: 'u1', flightId: 'FL1', isActive: true, createdAt: new Date().toISOString() },
+    ]
+
+    render(<FollowedFlightsCard />)
+    fireEvent.click(screen.getByLabelText('Stop following flight FL1'))
+
+    expect(unsubscribeMock).toHaveBeenCalledWith('a1')
+  })
+
+  it('falls back to a no-history message when the performance fetch fails', async () => {
+    global.fetch = jest.fn(async () => new Response('', { status: 500 })) as any
+    mockAlerts = [
+      { id: 'a1', userId: 'u1', flightId: 'FL1', isActive: true, createdAt: new Date().toISOString() },
+    ]
+
+    render(<FollowedFlightsCard />)
+
+    await waitFor(() => {
+      expect(screen.getByText('No on-time performance history yet')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/client/tests/hooks/useFlightStatusAlerts.test.tsx
+++ b/packages/client/tests/hooks/useFlightStatusAlerts.test.tsx
@@ -1,0 +1,120 @@
+import React from 'react'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useFlightStatusAlerts } from '@/hooks/useFlightStatusAlerts'
+
+const toastMock = jest.fn()
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}))
+
+const subscribeFlightMock = jest.fn()
+const unsubscribeFlightMock = jest.fn()
+jest.mock('@/components/socket/SocketProvider', () => ({
+  useSocket: () => ({
+    manager: {
+      subscribeFlight: subscribeFlightMock,
+      unsubscribeFlight: unsubscribeFlightMock,
+    },
+    connected: true,
+  }),
+}))
+
+let capturedOnFlightStatus: ((data: any) => void) | undefined
+jest.mock('@/hooks/use-socket-events', () => ({
+  useSocketEvents: (opts: any) => {
+    capturedOnFlightStatus = opts.onFlightStatus
+  },
+}))
+
+const mockAlert = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 'alert-1',
+  userId: 'user-1',
+  flightId: 'FL123',
+  isActive: true,
+  createdAt: new Date().toISOString(),
+  ...overrides,
+})
+
+describe('useFlightStatusAlerts real-time WS wiring (issue #333)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = jest.fn(async () =>
+      new Response(JSON.stringify({ data: [mockAlert()] }), { status: 200 }),
+    ) as any
+  })
+
+  it('subscribes to the flight room for each active alert after loading', async () => {
+    renderHook(() => useFlightStatusAlerts())
+
+    await waitFor(() => {
+      expect(subscribeFlightMock).toHaveBeenCalledWith('FL123')
+    })
+  })
+
+  it('unsubscribes from a flight room once its alert is removed', async () => {
+    const { result, rerender } = renderHook(() => useFlightStatusAlerts())
+
+    await waitFor(() => expect(subscribeFlightMock).toHaveBeenCalledWith('FL123'))
+
+    global.fetch = jest.fn(async () =>
+      new Response(JSON.stringify({ data: [] }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    ) as any
+
+    await act(async () => {
+      await result.current.unsubscribe('alert-1')
+    })
+    rerender()
+
+    await waitFor(() => expect(unsubscribeFlightMock).toHaveBeenCalledWith('FL123'))
+  })
+
+  it('updates the matching alert and shows a toast when a flight_status event arrives', async () => {
+    const { result } = renderHook(() => useFlightStatusAlerts())
+
+    await waitFor(() => expect(result.current.alerts).toHaveLength(1))
+    expect(capturedOnFlightStatus).toBeDefined()
+
+    act(() => {
+      capturedOnFlightStatus!({
+        flightId: 'FL123',
+        status: 'DELAYED',
+        detail: 'New departure 14:30',
+        timestamp: new Date('2026-08-01T12:00:00Z'),
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.alerts[0].lastStatus).toBe('DELAYED')
+    })
+    expect(result.current.alerts[0].lastNotifiedAt).toBe('2026-08-01T12:00:00.000Z')
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Flight FL123 status update' }),
+    )
+  })
+
+  it('ignores a flight_status event for a flight with no active alert', async () => {
+    const { result } = renderHook(() => useFlightStatusAlerts())
+    await waitFor(() => expect(result.current.alerts).toHaveLength(1))
+
+    act(() => {
+      capturedOnFlightStatus!({
+        flightId: 'UNRELATED',
+        status: 'CANCELLED',
+        timestamp: new Date(),
+      })
+    })
+
+    expect(toastMock).not.toHaveBeenCalled()
+    expect(result.current.alerts[0].lastStatus).toBeUndefined()
+  })
+
+  it('unsubscribes every tracked flight room on unmount', async () => {
+    const { unmount } = renderHook(() => useFlightStatusAlerts())
+
+    await waitFor(() => expect(subscribeFlightMock).toHaveBeenCalledWith('FL123'))
+
+    unmount()
+
+    expect(unsubscribeFlightMock).toHaveBeenCalledWith('FL123')
+  })
+})


### PR DESCRIPTION
## Summary

Closes #335
Closes #334 
Closes #333
Closes #332.

### #335 — Redis Cluster caching
- `REDIS_CLUSTER_NODES` env var (parsed by `cache/redisClusterConfig.ts`) switches `RedisSearchCache` (the flight-search cache) into ioredis Cluster mode instead of single-node, matching the `redis-cluster` docker-compose service already added for issue #383. Single-node behavior is unchanged when unset.
- New generic `services/cacheService.ts` — a reusable, cluster-aware cache (get/set/del/invalidatePrefix/getOrSet) for anything outside the flight-search path, distinct from the search-specific cache.
- New `jobs/cacheWarmingJob.ts`: periodically pre-warms the flight-search cache for the most frequently searched routes, derived from real `search_history_entries` (not a hardcoded list). Wired into `index.ts`.

### #334 — Sentry error tracking
- Backend Sentry integration (PII scrubbing, performance monitoring, error context enrichment) and source-map upload were already fully implemented. The one missing procedure step — a user feedback widget — is now added via `Sentry.feedbackIntegration()` in `sentry.client.config.ts`, plus a `global-error.tsx` root error boundary that reports crashes and opens the report dialog (Next.js App Router had no root error boundary at all before this).

### #333 — WebSocket real-time updates
- The server already broadcasts a typed `flight_status` event, but nothing on the client subscribed to a flight's room or listened for it — `broadcastFlightStatus`/`broadcastFlightAlert` were effectively dead in production. Added `onFlightStatus` to `use-socket-events.ts` and room subscribe/unsubscribe methods to `lib/socket.ts`, then wired `useFlightStatusAlerts` to join/leave rooms for the user's active alerts and update state in real time from `flight_status` events.

### #332 — Flight status notifications
- Extracted the notify+broadcast logic from the `/flight-status/report` route into `services/flightStatusNotifier.ts` (also fixes it to broadcast the typed `flight_status` event, not just the free-text `alert`, so #333's client wiring actually receives data from this path).
- New `jobs/flightStatusPollingJob.ts`: periodically re-checks status for every actively-followed flight and notifies on change — a catch-up path and the seam for a real status-feed integration later (current fetch is still the pre-existing mock, per `FlightStatusService`'s own docstring).
- New historical on-time performance tracking in `FlightStatusService` (bounded in-memory history of status transitions) + `GET /api/v1/flight-status/:flightId/performance`.
- New `FollowedFlightsCard` dashboard widget showing followed flights with live status + on-time rate, added to `app/dashboard/page.tsx`.

## Test plan
- [x] Unit tests added for all new modules (cache cluster config, cache service, cache warming job, flight status notifier, polling job, on-time performance, socket hooks, dashboard widget, error boundary, Sentry client config)
- [x] Manually traced every code path against existing conventions in the repo (no way to run `npm test`/`npm run typecheck` in this environment)
- [ ] `npm test` / `npm run lint` / `npm run typecheck` (please run in CI)