### PR TITLE
feat: add ancillary revenue services

### DIFF
--- a/docs/ANCILLARY_SERVICES.md
+++ b/docs/ANCILLARY_SERVICES.md
@@ -1,0 +1,48 @@
+# Ancillary services
+
+Traqora supports fixed-price trip extras, upgrade bids, gate upgrades, booking-aware
+recommendations, and ancillary revenue reporting. Prices are stored and returned in
+integer US-dollar cents.
+
+## Customer endpoints
+
+`GET /api/v1/ancillary/catalog` is public. It accepts `cabinClass` and an optional
+`airport`; lounge products are returned only when an airport is supplied.
+
+The following endpoints require the standard bearer token and enforce booking
+ownership when the booking has a wallet address:
+
+- `POST /api/v1/ancillary/purchases` purchases a catalog item using `bookingId`,
+  `serviceCode`, optional `quantity`, and optional `details`. Lounge purchases must
+  include `details.airport`.
+- `POST /api/v1/ancillary/upgrade-bids` creates a pending bid using `bookingId`,
+  `targetClass`, and `bidCents`.
+- `GET /api/v1/ancillary/recommendations/:bookingId` excludes services already
+  purchased for the booking.
+
+The server always resolves the price from its catalog. A caller cannot override a
+catalog price in the request.
+
+## Operational endpoints
+
+These endpoints require admin authentication:
+
+- `PATCH /api/v1/ancillary/upgrade-bids/:id` accepts or rejects a pending bid.
+- `POST /api/v1/ancillary/gate-upgrades` immediately fulfils an upgrade for a paid
+  or confirmed booking.
+- `GET /api/v1/ancillary/revenue?from=<ISO>&to=<ISO>` reports recognised revenue
+  by service type. Pending and rejected bids are excluded.
+
+All date filters are ISO-8601 timestamps. If omitted, the revenue range covers all
+records through the current time.
+
+## Database migration
+
+Run the standard backend migration command before using the endpoints:
+
+```sh
+npm run migration:run --workspace=packages/backend
+```
+
+The `ancillary_purchases` table is append-oriented except for the single transition
+of an upgrade bid from `bid_pending` to either `bid_accepted` or `bid_rejected`.

--- a/packages/backend/src/api/routes/ancillary.ts
+++ b/packages/backend/src/api/routes/ancillary.ts
@@ -1,0 +1,155 @@
+import { Request, Response, Router } from 'express';
+import { z } from 'zod';
+import { requireAuth } from '../../middleware/authMiddleware';
+import { requireAdmin } from '../../middleware/adminAuth';
+import {
+  ancillaryService,
+  getAncillaryCatalog,
+} from '../../services/ancillaryService';
+import { asyncHandler } from '../../utils/errorHandler';
+
+const router = Router();
+
+const detailsSchema = z.record(z.union([z.string(), z.number(), z.boolean()]));
+const upgradeClassSchema = z.enum(['premium', 'business', 'first']);
+
+const purchaseSchema = z.object({
+  bookingId: z.string().uuid(),
+  serviceCode: z.string().trim().min(1).max(48),
+  quantity: z.number().int().positive().max(9).default(1),
+  details: detailsSchema.optional(),
+});
+
+const upgradeBidSchema = z.object({
+  bookingId: z.string().uuid(),
+  targetClass: upgradeClassSchema,
+  bidCents: z.number().int().positive(),
+});
+
+const resolveBidSchema = z.object({
+  accepted: z.boolean(),
+});
+
+const gateUpgradeSchema = z.object({
+  bookingId: z.string().uuid(),
+  targetClass: upgradeClassSchema,
+  seatNumber: z.string().trim().min(1).max(8).optional(),
+});
+
+const revenueQuerySchema = z
+  .object({
+    from: z.string().datetime().optional(),
+    to: z.string().datetime().optional(),
+  })
+  .transform(({ from, to }) => ({
+    from: from ? new Date(from) : new Date(0),
+    to: to ? new Date(to) : new Date(),
+  }));
+
+/**
+ * GET /api/v1/ancillary/catalog
+ * Return purchasable services for a cabin and optional departure airport.
+ */
+router.get(
+  '/catalog',
+  (req: Request, res: Response) => {
+    const cabinClass = typeof req.query.cabinClass === 'string' ? req.query.cabinClass : undefined;
+    const airport = typeof req.query.airport === 'string' ? req.query.airport : undefined;
+    return res.json({ data: getAncillaryCatalog(cabinClass, airport) });
+  },
+);
+
+/**
+ * POST /api/v1/ancillary/purchases
+ * Purchase priority boarding, lounge access, extra legroom, or a fixed-price upgrade.
+ */
+router.post(
+  '/purchases',
+  requireAuth,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = purchaseSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+    const purchase = await ancillaryService.purchase(parsed.data, req.user?.walletAddress);
+    return res.status(201).json({ data: purchase });
+  }),
+);
+
+/**
+ * POST /api/v1/ancillary/upgrade-bids
+ * Place an upgrade bid. Pending bids are excluded from revenue until accepted.
+ */
+router.post(
+  '/upgrade-bids',
+  requireAuth,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = upgradeBidSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+    const bid = await ancillaryService.placeUpgradeBid(parsed.data, req.user?.walletAddress);
+    return res.status(201).json({ data: bid });
+  }),
+);
+
+/**
+ * PATCH /api/v1/ancillary/upgrade-bids/:id
+ * Accept or reject a pending upgrade bid.
+ */
+router.patch(
+  '/upgrade-bids/:id',
+  requireAdmin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = resolveBidSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+    const bid = await ancillaryService.resolveUpgradeBid(req.params.id, parsed.data.accepted);
+    return res.json({ data: bid });
+  }),
+);
+
+/**
+ * POST /api/v1/ancillary/gate-upgrades
+ * Fulfil a last-minute upgrade for an already paid booking.
+ */
+router.post(
+  '/gate-upgrades',
+  requireAdmin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = gateUpgradeSchema.safeParse(req.body);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+    const purchase = await ancillaryService.purchaseGateUpgrade(parsed.data);
+    return res.status(201).json({ data: purchase });
+  }),
+);
+
+/**
+ * GET /api/v1/ancillary/recommendations/:bookingId
+ * Return cabin-aware add-ons that have not already been purchased.
+ */
+router.get(
+  '/recommendations/:bookingId',
+  requireAuth,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = z.string().uuid().safeParse(req.params.bookingId);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+    const recommendations = await ancillaryService.recommendations(
+      parsed.data,
+      req.user?.walletAddress,
+    );
+    return res.json({ data: recommendations });
+  }),
+);
+
+/**
+ * GET /api/v1/ancillary/revenue
+ * Aggregate recognised ancillary revenue by service type and date range.
+ */
+router.get(
+  '/revenue',
+  requireAdmin,
+  asyncHandler(async (req: Request, res: Response) => {
+    const parsed = revenueQuerySchema.safeParse(req.query);
+    if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
+    const report = await ancillaryService.revenueReport(parsed.data.from, parsed.data.to);
+    return res.json({ data: report });
+  }),
+);
+
+export default router;

--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -23,6 +23,7 @@ import { collaborationRoutes } from './api/routes/collaboration';
 import { authRoutes } from './api/routes/auth';
 import disputeRoutes from './api/routes/disputes';
 import serviceRoutes from './api/routes/services';
+import ancillaryRoutes from './api/routes/ancillary';
 import contractEventRoutes from './api/routes/contract-events';
 import transactionRoutes from './api/routes/transactions';
 import checkinRoutes from './api/routes/checkin';
@@ -222,6 +223,7 @@ export const createApp = async (options: AppOptions = {}) => {
   app.use('/api/v1/collaboration', collaborationRoutes);
   app.use('/api/v1/disputes', disputeRoutes);
   app.use('/api/v1/services', serviceRoutes);
+  app.use('/api/v1/ancillary', ancillaryRoutes);
   app.use('/api/v1/contract-events', contractEventRoutes);
   app.use('/api/v1/transactions', transactionRoutes);
   app.use('/api/v1/checkin', requireAuth, checkinRoutes);

--- a/packages/backend/src/db/dataSource.ts
+++ b/packages/backend/src/db/dataSource.ts
@@ -36,6 +36,7 @@ import { CarbonOffset } from "./entities/CarbonOffset";
 import { OffsetProject } from "./entities/OffsetProject";
 import { TrackedFlight } from "./entities/TrackedFlight";
 import { PriceObservation } from "./entities/PriceObservation";
+import { AncillaryPurchase } from "./entities/AncillaryPurchase";
 
 const isTest = process.env.NODE_ENV === "test";
 
@@ -81,6 +82,7 @@ export const AppDataSource = new DataSource(
         OffsetProject,
         TrackedFlight,
         PriceObservation,
+        AncillaryPurchase,
       ],
       logging: false,
     }
@@ -124,6 +126,7 @@ export const AppDataSource = new DataSource(
         OffsetProject,
         TrackedFlight,
         PriceObservation,
+        AncillaryPurchase,
       ],
       migrations: [__dirname + "/migrations/*.{js,ts}"],
       ssl:

--- a/packages/backend/src/db/entities/AncillaryPurchase.ts
+++ b/packages/backend/src/db/entities/AncillaryPurchase.ts
@@ -1,0 +1,63 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from "typeorm";
+
+export type AncillaryServiceType =
+  | "seat_upgrade"
+  | "priority_boarding"
+  | "lounge_access"
+  | "extra_legroom";
+
+export type AncillaryPurchaseStatus =
+  | "purchased"
+  | "fulfilled"
+  | "bid_pending"
+  | "bid_accepted"
+  | "bid_rejected";
+
+@Entity({ name: "ancillary_purchases" })
+@Index("idx_ancillary_booking", ["bookingId"])
+@Index("idx_ancillary_type_created", ["serviceType", "createdAt"])
+export class AncillaryPurchase {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "uuid" })
+  bookingId!: string;
+
+  @Column({ type: "varchar", length: 48 })
+  serviceCode!: string;
+
+  @Column({ type: "varchar", length: 32 })
+  serviceType!: AncillaryServiceType;
+
+  @Column({ type: "integer" })
+  amountCents!: number;
+
+  @Column({ type: "integer", default: 1 })
+  quantity!: number;
+
+  @Column({ type: "varchar", length: 24 })
+  status!: AncillaryPurchaseStatus;
+
+  @Column({
+    type: process.env.NODE_ENV === "test" ? "simple-json" : "jsonb",
+    nullable: true,
+  })
+  details?: Record<string, string | number | boolean> | null;
+
+  @CreateDateColumn({
+    type: process.env.NODE_ENV === "test" ? "datetime" : "timestamptz",
+  })
+  createdAt!: Date;
+
+  @UpdateDateColumn({
+    type: process.env.NODE_ENV === "test" ? "datetime" : "timestamptz",
+  })
+  updatedAt!: Date;
+}

--- a/packages/backend/src/db/migrations/1766000000000-CreateAncillaryPurchases.ts
+++ b/packages/backend/src/db/migrations/1766000000000-CreateAncillaryPurchases.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateAncillaryPurchases1766000000000
+  implements MigrationInterface
+{
+  name = "CreateAncillaryPurchases1766000000000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "ancillary_purchases" (
+        "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        "bookingId" uuid NOT NULL REFERENCES "bookings"("id") ON DELETE CASCADE,
+        "serviceCode" varchar(48) NOT NULL,
+        "serviceType" varchar(32) NOT NULL,
+        "amountCents" integer NOT NULL CHECK ("amountCents" > 0),
+        "quantity" integer NOT NULL DEFAULT 1 CHECK ("quantity" > 0),
+        "status" varchar(24) NOT NULL,
+        "details" jsonb,
+        "createdAt" timestamptz NOT NULL DEFAULT now(),
+        "updatedAt" timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_ancillary_booking" ON "ancillary_purchases" ("bookingId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_ancillary_type_created" ON "ancillary_purchases" ("serviceType", "createdAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "idx_ancillary_type_created"`,
+    );
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_ancillary_booking"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "ancillary_purchases"`);
+  }
+}

--- a/packages/backend/src/services/ancillaryService.test.ts
+++ b/packages/backend/src/services/ancillaryService.test.ts
@@ -1,0 +1,282 @@
+import { Repository } from 'typeorm';
+import { Booking } from '../db/entities/Booking';
+import { AncillaryPurchase } from '../db/entities/AncillaryPurchase';
+import { BadRequestError, NotFoundError } from '../utils/errors';
+import {
+  AncillaryRepositories,
+  AncillaryService,
+  getAncillaryCatalog,
+  normalizeCabinClass,
+  recommendAncillaryServices,
+  summarizeAncillaryRevenue,
+} from './ancillaryService';
+
+function purchase(overrides: Partial<AncillaryPurchase> = {}): AncillaryPurchase {
+  return {
+    id: 'purchase-id',
+    bookingId: 'booking-id',
+    serviceCode: 'PRIORITY_BOARDING',
+    serviceType: 'priority_boarding',
+    amountCents: 2500,
+    quantity: 1,
+    status: 'purchased',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function booking(overrides: Partial<Booking> = {}): Booking {
+  return {
+    id: 'booking-id',
+    flight: {
+      id: 'flight-id',
+      fromAirport: 'JFK',
+      rawData: { cabinClass: 'economy' },
+    } as Booking['flight'],
+    passenger: {} as Booking['passenger'],
+    status: 'paid',
+    amountCents: 50000,
+    contractSubmitAttempts: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function setup(bookingResult: Booking | null = booking()) {
+  const bookingRepository = {
+    findOne: jest.fn().mockResolvedValue(bookingResult),
+  };
+  const purchaseRepository = {
+    create: jest.fn((value) => value),
+    save: jest.fn(async (value) => ({ id: 'saved-id', ...value })),
+    find: jest.fn().mockResolvedValue([]),
+    findOne: jest.fn(),
+  };
+  const repositories = {
+    bookings: bookingRepository as unknown as Repository<Booking>,
+    purchases: purchaseRepository as unknown as Repository<AncillaryPurchase>,
+  } satisfies AncillaryRepositories;
+  return {
+    service: new AncillaryService(() => repositories),
+    bookingRepository,
+    purchaseRepository,
+  };
+}
+
+describe('ancillary catalog helpers', () => {
+  it('normalizes supported cabin names and defaults unknown values', () => {
+    expect(normalizeCabinClass('Premium Economy')).toBe('premium');
+    expect(normalizeCabinClass('BUSINESS')).toBe('business');
+    expect(normalizeCabinClass('unknown')).toBe('economy');
+  });
+
+  it('filters services by cabin and only offers lounge access when an airport is supplied', () => {
+    const withoutAirport = getAncillaryCatalog('economy');
+    expect(withoutAirport.some((item) => item.code === 'LOUNGE_STANDARD')).toBe(false);
+    expect(withoutAirport.some((item) => item.code === 'EXTRA_LEGROOM')).toBe(true);
+
+    const withAirport = getAncillaryCatalog('first', 'JFK');
+    expect(withAirport.map((item) => item.code)).toEqual(
+      expect.arrayContaining(['PRIORITY_BOARDING', 'LOUNGE_STANDARD']),
+    );
+    expect(withAirport.some((item) => item.type === 'seat_upgrade')).toBe(false);
+  });
+
+  it('does not recommend services that were already purchased', () => {
+    const recommendations = recommendAncillaryServices('economy', ['EXTRA_LEGROOM']);
+    expect(recommendations.some((item) => item.code === 'EXTRA_LEGROOM')).toBe(false);
+    expect(recommendations.some((item) => item.code === 'PRIORITY_BOARDING')).toBe(true);
+  });
+
+  it('recognises only completed revenue and accounts for quantity', () => {
+    const report = summarizeAncillaryRevenue([
+      purchase({ quantity: 2 }),
+      purchase({
+        id: 'accepted-bid',
+        serviceType: 'seat_upgrade',
+        amountCents: 10000,
+        status: 'bid_accepted',
+      }),
+      purchase({ id: 'pending-bid', amountCents: 50000, status: 'bid_pending' }),
+      purchase({ id: 'rejected-bid', amountCents: 50000, status: 'bid_rejected' }),
+    ]);
+
+    expect(report.totalCents).toBe(15000);
+    expect(report.purchaseCount).toBe(2);
+    expect(report.byType.priority_boarding).toEqual({ totalCents: 5000, purchaseCount: 1 });
+    expect(report.byType.seat_upgrade).toEqual({ totalCents: 10000, purchaseCount: 1 });
+  });
+});
+
+describe('AncillaryService', () => {
+  it('purchases an eligible catalog service at the server-controlled price', async () => {
+    const { service, purchaseRepository } = setup();
+    const result = await service.purchase({
+      bookingId: 'booking-id',
+      serviceCode: 'PRIORITY_BOARDING',
+      quantity: 2,
+    });
+
+    expect(result).toMatchObject({
+      serviceCode: 'PRIORITY_BOARDING',
+      amountCents: 2500,
+      quantity: 2,
+      status: 'purchased',
+    });
+    expect(purchaseRepository.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects unknown, ineligible, and incomplete lounge purchases', async () => {
+    const { service } = setup(
+      booking({ flight: { id: 'flight-id', rawData: { cabinClass: 'business' } } as Booking['flight'] }),
+    );
+    await expect(
+      service.purchase({ bookingId: 'booking-id', serviceCode: 'NO_SUCH_SERVICE' }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    await expect(
+      service.purchase({ bookingId: 'booking-id', serviceCode: 'EXTRA_LEGROOM' }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    await expect(
+      service.purchase({ bookingId: 'booking-id', serviceCode: 'LOUNGE_STANDARD' }),
+    ).rejects.toThrow('An airport is required');
+  });
+
+  it('returns not found when the booking does not exist', async () => {
+    const { service } = setup(null);
+    await expect(
+      service.purchase({ bookingId: 'missing', serviceCode: 'PRIORITY_BOARDING' }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('prevents a wallet from purchasing extras for another wallet booking', async () => {
+    const { service } = setup(booking({ walletAddress: 'GBOOKINGOWNER' }));
+    await expect(
+      service.purchase(
+        { bookingId: 'booking-id', serviceCode: 'PRIORITY_BOARDING' },
+        'GDIFFERENTWALLET',
+      ),
+    ).rejects.toThrow('different wallet');
+  });
+
+  it('enforces minimum upgrade bids and stores valid bids as pending', async () => {
+    const { service } = setup();
+    await expect(
+      service.placeUpgradeBid({
+        bookingId: 'booking-id',
+        targetClass: 'business',
+        bidCents: 24999,
+      }),
+    ).rejects.toThrow('Minimum business upgrade bid');
+
+    await expect(
+      service.placeUpgradeBid({
+        bookingId: 'booking-id',
+        targetClass: 'business',
+        bidCents: 25000,
+      }),
+    ).resolves.toMatchObject({
+      serviceCode: 'UPGRADE_BID_BUSINESS',
+      amountCents: 25000,
+      status: 'bid_pending',
+    });
+
+    const businessBooking = setup(
+      booking({
+        flight: {
+          id: 'flight-id',
+          fromAirport: 'JFK',
+          rawData: { cabinClass: 'business' },
+        } as Booking['flight'],
+      }),
+    );
+    await expect(
+      businessBooking.service.placeUpgradeBid({
+        bookingId: 'booking-id',
+        targetClass: 'premium',
+        bidCents: 10000,
+      }),
+    ).rejects.toThrow('higher than the current cabin');
+  });
+
+  it('accepts or rejects only pending bids', async () => {
+    const acceptedSetup = setup();
+    acceptedSetup.purchaseRepository.findOne.mockResolvedValue(purchase({ status: 'bid_pending' }));
+    await expect(acceptedSetup.service.resolveUpgradeBid('bid-id', true)).resolves.toMatchObject({
+      status: 'bid_accepted',
+    });
+
+    const rejectedSetup = setup();
+    rejectedSetup.purchaseRepository.findOne.mockResolvedValue(purchase({ status: 'bid_pending' }));
+    await expect(rejectedSetup.service.resolveUpgradeBid('bid-id', false)).resolves.toMatchObject({
+      status: 'bid_rejected',
+    });
+
+    const missingSetup = setup();
+    missingSetup.purchaseRepository.findOne.mockResolvedValue(null);
+    await expect(missingSetup.service.resolveUpgradeBid('missing', true)).rejects.toBeInstanceOf(
+      NotFoundError,
+    );
+  });
+
+  it('allows gate upgrades only for paid bookings', async () => {
+    const unpaid = setup(booking({ status: 'created' }));
+    await expect(
+      unpaid.service.purchaseGateUpgrade({ bookingId: 'booking-id', targetClass: 'premium' }),
+    ).rejects.toThrow('paid or confirmed');
+
+    const paid = setup();
+    await expect(
+      paid.service.purchaseGateUpgrade({
+        bookingId: 'booking-id',
+        targetClass: 'first',
+        seatNumber: '2A',
+      }),
+    ).resolves.toMatchObject({
+      serviceCode: 'GATE_UPGRADE_FIRST',
+      amountCents: 80000,
+      status: 'fulfilled',
+      details: { targetClass: 'first', seatNumber: '2A', purchasedAtGate: true },
+    });
+
+    const firstClass = setup(
+      booking({
+        flight: {
+          id: 'flight-id',
+          fromAirport: 'JFK',
+          rawData: { cabinClass: 'first' },
+        } as Booking['flight'],
+      }),
+    );
+    await expect(
+      firstClass.service.purchaseGateUpgrade({
+        bookingId: 'booking-id',
+        targetClass: 'first',
+      }),
+    ).rejects.toThrow('higher than the current cabin');
+  });
+
+  it('builds recommendations from the booking cabin and active purchases', async () => {
+    const { service, purchaseRepository } = setup();
+    purchaseRepository.find.mockResolvedValue([
+      purchase({ serviceCode: 'PRIORITY_BOARDING' }),
+      purchase({ serviceCode: 'EXTRA_LEGROOM', status: 'bid_rejected' }),
+    ]);
+    const recommendations = await service.recommendations('booking-id');
+    expect(recommendations.some((item) => item.code === 'PRIORITY_BOARDING')).toBe(false);
+    expect(recommendations.some((item) => item.code === 'EXTRA_LEGROOM')).toBe(true);
+    expect(recommendations.some((item) => item.code === 'LOUNGE_STANDARD')).toBe(true);
+  });
+
+  it('validates report dates and aggregates repository results', async () => {
+    const { service, purchaseRepository } = setup();
+    purchaseRepository.find.mockResolvedValue([purchase()]);
+    await expect(
+      service.revenueReport(new Date('2026-02-01'), new Date('2026-01-01')),
+    ).rejects.toThrow('"from" must be before "to"');
+    await expect(
+      service.revenueReport(new Date('2026-01-01'), new Date('2026-02-01')),
+    ).resolves.toMatchObject({ totalCents: 2500, purchaseCount: 1 });
+  });
+});

--- a/packages/backend/src/services/ancillaryService.ts
+++ b/packages/backend/src/services/ancillaryService.ts
@@ -1,0 +1,320 @@
+import { Between, Repository } from 'typeorm';
+import { AppDataSource } from '../db/dataSource';
+import { Booking } from '../db/entities/Booking';
+import {
+  AncillaryPurchase,
+  AncillaryPurchaseStatus,
+  AncillaryServiceType,
+} from '../db/entities/AncillaryPurchase';
+import { BadRequestError, ForbiddenError, NotFoundError } from '../utils/errors';
+
+export type CabinClass = 'economy' | 'premium' | 'business' | 'first';
+
+export interface AncillaryCatalogItem {
+  code: string;
+  name: string;
+  description: string;
+  type: AncillaryServiceType;
+  priceCents: number;
+  availableCabins: CabinClass[];
+  requiresAirport?: boolean;
+  availableAtGate?: boolean;
+}
+
+export interface PurchaseAncillaryInput {
+  bookingId: string;
+  serviceCode: string;
+  quantity?: number;
+  details?: Record<string, string | number | boolean>;
+}
+
+export interface UpgradeBidInput {
+  bookingId: string;
+  targetClass: Exclude<CabinClass, 'economy'>;
+  bidCents: number;
+}
+
+export interface GateUpgradeInput {
+  bookingId: string;
+  targetClass: Exclude<CabinClass, 'economy'>;
+  seatNumber?: string;
+}
+
+export interface AncillaryRevenueReport {
+  totalCents: number;
+  purchaseCount: number;
+  byType: Record<AncillaryServiceType, { totalCents: number; purchaseCount: number }>;
+}
+
+export interface AncillaryRepositories {
+  bookings: Repository<Booking>;
+  purchases: Repository<AncillaryPurchase>;
+}
+
+const ALL_CABINS: CabinClass[] = ['economy', 'premium', 'business', 'first'];
+const CABIN_RANK: Record<CabinClass, number> = {
+  economy: 0,
+  premium: 1,
+  business: 2,
+  first: 3,
+};
+
+export const ANCILLARY_CATALOG: AncillaryCatalogItem[] = [
+  {
+    code: 'SEAT_UPGRADE_PREMIUM',
+    name: 'Premium cabin upgrade',
+    description: 'Upgrade to premium seating with more space and priority service.',
+    type: 'seat_upgrade',
+    priceCents: 12500,
+    availableCabins: ['economy'],
+  },
+  {
+    code: 'SEAT_UPGRADE_BUSINESS',
+    name: 'Business cabin upgrade',
+    description: 'Move to business class when inventory is available.',
+    type: 'seat_upgrade',
+    priceCents: 45000,
+    availableCabins: ['economy', 'premium'],
+  },
+  {
+    code: 'PRIORITY_BOARDING',
+    name: 'Priority boarding',
+    description: 'Board in an earlier group and settle in before general boarding.',
+    type: 'priority_boarding',
+    priceCents: 2500,
+    availableCabins: ALL_CABINS,
+  },
+  {
+    code: 'LOUNGE_STANDARD',
+    name: 'Airport lounge access',
+    description: 'One-time lounge admission before departure.',
+    type: 'lounge_access',
+    priceCents: 4500,
+    availableCabins: ALL_CABINS,
+    requiresAirport: true,
+  },
+  {
+    code: 'EXTRA_LEGROOM',
+    name: 'Extra legroom seat',
+    description: 'Reserve a seat with additional pitch, subject to availability.',
+    type: 'extra_legroom',
+    priceCents: 3500,
+    availableCabins: ['economy', 'premium'],
+    availableAtGate: true,
+  },
+];
+
+const MINIMUM_UPGRADE_BIDS: Record<Exclude<CabinClass, 'economy'>, number> = {
+  premium: 7500,
+  business: 25000,
+  first: 50000,
+};
+
+const GATE_UPGRADE_PRICES: Record<Exclude<CabinClass, 'economy'>, number> = {
+  premium: 20000,
+  business: 50000,
+  first: 80000,
+};
+
+const REVENUE_STATUSES = new Set<AncillaryPurchaseStatus>([
+  'purchased',
+  'fulfilled',
+  'bid_accepted',
+]);
+
+export function normalizeCabinClass(value?: string): CabinClass {
+  const normalized = value?.trim().toLowerCase().replace(/[\s-]+/g, '_');
+  if (normalized === 'premium_economy' || normalized === 'premium') return 'premium';
+  if (normalized === 'business') return 'business';
+  if (normalized === 'first') return 'first';
+  return 'economy';
+}
+
+export function getAncillaryCatalog(
+  cabinClass?: string,
+  airport?: string,
+): AncillaryCatalogItem[] {
+  const cabin = normalizeCabinClass(cabinClass);
+  return ANCILLARY_CATALOG.filter(
+    (item) =>
+      item.availableCabins.includes(cabin) &&
+      (!item.requiresAirport || Boolean(airport?.trim())),
+  );
+}
+
+export function recommendAncillaryServices(
+  cabinClass: string | undefined,
+  purchasedCodes: string[],
+  airport?: string,
+): AncillaryCatalogItem[] {
+  const purchased = new Set(purchasedCodes);
+  return getAncillaryCatalog(cabinClass, airport).filter(
+    (item) => !purchased.has(item.code),
+  );
+}
+
+export function summarizeAncillaryRevenue(
+  purchases: AncillaryPurchase[],
+): AncillaryRevenueReport {
+  const byType: AncillaryRevenueReport['byType'] = {
+    seat_upgrade: { totalCents: 0, purchaseCount: 0 },
+    priority_boarding: { totalCents: 0, purchaseCount: 0 },
+    lounge_access: { totalCents: 0, purchaseCount: 0 },
+    extra_legroom: { totalCents: 0, purchaseCount: 0 },
+  };
+
+  let totalCents = 0;
+  let purchaseCount = 0;
+  for (const purchase of purchases) {
+    if (!REVENUE_STATUSES.has(purchase.status)) continue;
+    const lineTotal = purchase.amountCents * purchase.quantity;
+    totalCents += lineTotal;
+    purchaseCount += 1;
+    byType[purchase.serviceType].totalCents += lineTotal;
+    byType[purchase.serviceType].purchaseCount += 1;
+  }
+
+  return { totalCents, purchaseCount, byType };
+}
+
+function defaultRepositories(): AncillaryRepositories {
+  return {
+    bookings: AppDataSource.getRepository(Booking),
+    purchases: AppDataSource.getRepository(AncillaryPurchase),
+  };
+}
+
+export class AncillaryService {
+  constructor(private readonly repositories: () => AncillaryRepositories = defaultRepositories) {}
+
+  private async getBooking(bookingId: string, walletAddress?: string): Promise<Booking> {
+    const booking = await this.repositories().bookings.findOne({
+      where: { id: bookingId },
+      relations: ['flight'],
+    });
+    if (!booking) throw new NotFoundError('Booking not found');
+    if (walletAddress && booking.walletAddress && booking.walletAddress !== walletAddress) {
+      throw new ForbiddenError('This booking belongs to a different wallet');
+    }
+    return booking;
+  }
+
+  async purchase(input: PurchaseAncillaryInput, walletAddress?: string): Promise<AncillaryPurchase> {
+    const booking = await this.getBooking(input.bookingId, walletAddress);
+    const item = ANCILLARY_CATALOG.find((candidate) => candidate.code === input.serviceCode);
+    if (!item) throw new BadRequestError('Unknown ancillary service code');
+
+    const cabin = normalizeCabinClass(booking.flight?.rawData?.cabinClass as string | undefined);
+    if (!item.availableCabins.includes(cabin)) {
+      throw new BadRequestError(`${item.name} is not available for ${cabin} cabin`);
+    }
+    if (item.requiresAirport && typeof input.details?.airport !== 'string') {
+      throw new BadRequestError('An airport is required for lounge access');
+    }
+
+    const quantity = input.quantity ?? 1;
+    const repository = this.repositories().purchases;
+    return repository.save(
+      repository.create({
+        bookingId: input.bookingId,
+        serviceCode: item.code,
+        serviceType: item.type,
+        amountCents: item.priceCents,
+        quantity,
+        status: 'purchased',
+        details: input.details,
+      }),
+    );
+  }
+
+  async placeUpgradeBid(input: UpgradeBidInput, walletAddress?: string): Promise<AncillaryPurchase> {
+    const booking = await this.getBooking(input.bookingId, walletAddress);
+    const currentCabin = normalizeCabinClass(
+      booking.flight?.rawData?.cabinClass as string | undefined,
+    );
+    if (CABIN_RANK[input.targetClass] <= CABIN_RANK[currentCabin]) {
+      throw new BadRequestError('Target cabin must be higher than the current cabin');
+    }
+    const minimumBid = MINIMUM_UPGRADE_BIDS[input.targetClass];
+    if (input.bidCents < minimumBid) {
+      throw new BadRequestError(`Minimum ${input.targetClass} upgrade bid is ${minimumBid} cents`);
+    }
+
+    const repository = this.repositories().purchases;
+    return repository.save(
+      repository.create({
+        bookingId: input.bookingId,
+        serviceCode: `UPGRADE_BID_${input.targetClass.toUpperCase()}`,
+        serviceType: 'seat_upgrade',
+        amountCents: input.bidCents,
+        quantity: 1,
+        status: 'bid_pending',
+        details: { targetClass: input.targetClass },
+      }),
+    );
+  }
+
+  async resolveUpgradeBid(id: string, accepted: boolean): Promise<AncillaryPurchase> {
+    const repository = this.repositories().purchases;
+    const bid = await repository.findOne({ where: { id, status: 'bid_pending' } });
+    if (!bid) throw new NotFoundError('Pending upgrade bid not found');
+    bid.status = accepted ? 'bid_accepted' : 'bid_rejected';
+    return repository.save(bid);
+  }
+
+  async purchaseGateUpgrade(input: GateUpgradeInput): Promise<AncillaryPurchase> {
+    const booking = await this.getBooking(input.bookingId);
+    if (!['paid', 'onchain_submitted', 'confirmed'].includes(booking.status)) {
+      throw new BadRequestError('Gate upgrades require a paid or confirmed booking');
+    }
+    const currentCabin = normalizeCabinClass(
+      booking.flight?.rawData?.cabinClass as string | undefined,
+    );
+    if (CABIN_RANK[input.targetClass] <= CABIN_RANK[currentCabin]) {
+      throw new BadRequestError('Target cabin must be higher than the current cabin');
+    }
+
+    const repository = this.repositories().purchases;
+    return repository.save(
+      repository.create({
+        bookingId: input.bookingId,
+        serviceCode: `GATE_UPGRADE_${input.targetClass.toUpperCase()}`,
+        serviceType: 'seat_upgrade',
+        amountCents: GATE_UPGRADE_PRICES[input.targetClass],
+        quantity: 1,
+        status: 'fulfilled',
+        details: {
+          targetClass: input.targetClass,
+          ...(input.seatNumber ? { seatNumber: input.seatNumber } : {}),
+          purchasedAtGate: true,
+        },
+      }),
+    );
+  }
+
+  async recommendations(
+    bookingId: string,
+    walletAddress?: string,
+  ): Promise<AncillaryCatalogItem[]> {
+    const booking = await this.getBooking(bookingId, walletAddress);
+    const purchases = await this.repositories().purchases.find({ where: { bookingId } });
+    const cabin = booking.flight?.rawData?.cabinClass as string | undefined;
+    return recommendAncillaryServices(
+      cabin,
+      purchases
+        .filter((purchase) => purchase.status !== 'bid_rejected')
+        .map((purchase) => purchase.serviceCode),
+      booking.flight?.fromAirport,
+    );
+  }
+
+  async revenueReport(from: Date, to: Date): Promise<AncillaryRevenueReport> {
+    if (from > to) throw new BadRequestError('"from" must be before "to"');
+    const purchases = await this.repositories().purchases.find({
+      where: { createdAt: Between(from, to) },
+    });
+    return summarizeAncillaryRevenue(purchases);
+  }
+}
+
+export const ancillaryService = new AncillaryService();

--- a/packages/client/app/admin/page.tsx
+++ b/packages/client/app/admin/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { AncillaryRevenueDashboard } from "@/components/booking/ancillary-revenue-dashboard"
 import {
   Plane,
   Users,
@@ -192,6 +193,10 @@ export default function AdminDashboard() {
               </div>
             </CardContent>
           </Card>
+        </div>
+
+        <div className="mb-8">
+          <AncillaryRevenueDashboard />
         </div>
 
         <div className="grid lg:grid-cols-3 gap-8">

--- a/packages/client/app/book/[id]/page.tsx
+++ b/packages/client/app/book/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react"
 
 import { SeatSelector } from "@/components/booking/seat-selector"
+import { AncillarySelector } from "@/components/booking/ancillary-selector"
 import { BookingSummary } from "@/components/booking/booking-summary"
 import { InsuranceSelector } from "@/components/booking/insurance-selector"
 import { CarbonFootprintDisplay } from "@/components/booking/carbon-footprint-display"
@@ -42,6 +43,10 @@ import {
   purchaseOffset,
   CarbonFootprint,
 } from "@/lib/api"
+import {
+  AncillaryCatalogItem,
+  purchaseAncillaryService,
+} from "@/lib/ancillary-api"
 import {
   type CurrencyCode,
   getCurrencyFromStorage,
@@ -74,7 +79,7 @@ const mockFlightDetails = {
   refundPolicy: "Free cancellation up to 24 hours before departure",
 }
 
-type BookingStep = "details" | "seats" | "insurance" | "carbon" | "wallet" | "confirm" | "success"
+type BookingStep = "details" | "seats" | "extras" | "insurance" | "carbon" | "wallet" | "confirm" | "success"
 
 export default function BookFlightPage() {
   const params = useParams()
@@ -99,6 +104,8 @@ export default function BookFlightPage() {
 
   const [bookingId, setBookingId] = useState("")
   const [selectedCoverage, setSelectedCoverage] = useState<InsuranceCoverageType | null>(null)
+  const [selectedAncillaries, setSelectedAncillaries] = useState<AncillaryCatalogItem[]>([])
+  const [isPurchasingAncillaries, setIsPurchasingAncillaries] = useState(false)
   const [insurancePolicy, setInsurancePolicy] = useState<InsurancePolicy | null>(null)
   const [isPurchasingInsurance, setIsPurchasingInsurance] = useState(false)
   const [isCarbonNeutral, setIsCarbonNeutral] = useState(false)
@@ -169,6 +176,7 @@ export default function BookFlightPage() {
   const steps: { id: BookingStep; label: string }[] = [
     { id: "details", label: "Flight Details" },
     { id: "seats", label: "Seat Selection" },
+    { id: "extras", label: "Trip Extras" },
     { id: "insurance", label: "Travel Insurance" },
     { id: "carbon", label: "Carbon Offsets" },
     { id: "wallet", label: "Connect Wallet" },
@@ -238,6 +246,26 @@ export default function BookFlightPage() {
   const handleFinalConfirm = async () => {
     const newBookingId = "TRAQ-" + Math.random().toString(36).substring(2, 9).toUpperCase()
     setBookingId(newBookingId)
+
+    if (booking?.id && selectedAncillaries.length > 0) {
+      setIsPurchasingAncillaries(true)
+      try {
+        await Promise.all(
+          selectedAncillaries.map((item) =>
+            purchaseAncillaryService({
+              bookingId: booking.id,
+              serviceCode: item.code,
+              details: item.requiresAirport ? { airport: flight.from } : undefined,
+            }),
+          ),
+        )
+      } catch (error) {
+        console.error("Ancillary purchase failed", error)
+        setIsPurchasingAncillaries(false)
+        return
+      }
+      setIsPurchasingAncillaries(false)
+    }
 
     if (selectedCoverage) {
       setIsPurchasingInsurance(true)
@@ -406,7 +434,30 @@ export default function BookFlightPage() {
               </div>
             )}
 
-            {/* Step 3: Travel Insurance */}
+            {currentStep === "extras" && (
+              <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+                <AncillarySelector
+                  cabinClass={flight.class}
+                  airport={flight.from}
+                  selectedCodes={selectedAncillaries.map((item) => item.code)}
+                  onSelectionChange={setSelectedAncillaries}
+                  displayCurrency={displayCurrency}
+                  rates={rates}
+                />
+                <div className="flex justify-between">
+                  <Button variant="ghost" onClick={prevStep}>
+                    <ArrowLeft className="mr-2 h-4 w-4" />
+                    Back
+                  </Button>
+                  <Button size="lg" onClick={nextStep}>
+                    Continue
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {/* Step 4: Travel Insurance */}
             {currentStep === "insurance" && (
               <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
                 <InsuranceSelector
@@ -532,10 +583,10 @@ export default function BookFlightPage() {
                   <Button
                     size="lg"
                     onClick={handleFinalConfirm}
-                    disabled={isPurchasingInsurance || isPurchasingOffset}
+                    disabled={isPurchasingInsurance || isPurchasingOffset || isPurchasingAncillaries}
                     className="px-12 shadow-lg bg-green-600 hover:bg-green-700 text-white"
                   >
-                    {isPurchasingInsurance || isPurchasingOffset ? "Processing..." : "Confirm & Pay"}
+                    {isPurchasingInsurance || isPurchasingOffset || isPurchasingAncillaries ? "Processing..." : "Confirm & Pay"}
                   </Button>
                 </div>
               </div>
@@ -681,6 +732,17 @@ export default function BookFlightPage() {
                 carbonOffset={
                   isCarbonNeutral && offsetCostCents > 0
                     ? { costCents: offsetCostCents }
+                    : undefined
+                }
+                ancillaries={
+                  selectedAncillaries.length > 0
+                    ? {
+                        count: selectedAncillaries.length,
+                        totalCents: selectedAncillaries.reduce(
+                          (total, item) => total + item.priceCents,
+                          0,
+                        ),
+                      }
                     : undefined
                 }
                 displayCurrency={displayCurrency}

--- a/packages/client/components/booking/ancillary-revenue-dashboard.tsx
+++ b/packages/client/components/booking/ancillary-revenue-dashboard.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  AncillaryRevenueReport,
+  AncillaryServiceType,
+  fetchAncillaryRevenue,
+} from '@/lib/ancillary-api';
+import { formatCurrency } from '@/lib/currency';
+
+const labels: Record<AncillaryServiceType, string> = {
+  seat_upgrade: 'Seat upgrades',
+  priority_boarding: 'Priority boarding',
+  lounge_access: 'Lounge access',
+  extra_legroom: 'Extra legroom',
+};
+
+export function AncillaryRevenueDashboard({ from, to }: { from?: Date; to?: Date }) {
+  const [report, setReport] = useState<AncillaryRevenueReport | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    fetchAncillaryRevenue(from, to)
+      .then((data) => {
+        if (active) setReport(data);
+      })
+      .catch(() => {
+        if (active) setError('Unable to load ancillary revenue.');
+      });
+    return () => {
+      active = false;
+    };
+  }, [from, to]);
+
+  if (error) return <p role="alert">{error}</p>;
+  if (!report) return <p role="status">Loading ancillary revenue…</p>;
+
+  return (
+    <section aria-labelledby="ancillary-revenue-heading" className="space-y-4">
+      <div>
+        <h2 id="ancillary-revenue-heading" className="text-2xl font-bold">Ancillary revenue</h2>
+        <p className="text-muted-foreground">{report.purchaseCount} recognised purchases</p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
+        <Card>
+          <CardHeader><CardTitle>Total</CardTitle></CardHeader>
+          <CardContent className="text-2xl font-bold">
+            {formatCurrency(report.totalCents / 100, 'USD')}
+          </CardContent>
+        </Card>
+        {(Object.keys(labels) as AncillaryServiceType[]).map((type) => (
+          <Card key={type}>
+            <CardHeader><CardTitle>{labels[type]}</CardTitle></CardHeader>
+            <CardContent>
+              <p className="text-xl font-bold">
+                {formatCurrency(report.byType[type].totalCents / 100, 'USD')}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {report.byType[type].purchaseCount} purchases
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/client/components/booking/ancillary-selector.tsx
+++ b/packages/client/components/booking/ancillary-selector.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Armchair, Check, Crown, DoorOpen, Sparkles } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  AncillaryCatalogItem,
+  AncillaryServiceType,
+  fetchAncillaryCatalog,
+} from '@/lib/ancillary-api';
+import { CurrencyCode, formatCurrency } from '@/lib/currency';
+import { cn } from '@/lib/utils';
+
+const serviceIcons: Record<AncillaryServiceType, typeof Armchair> = {
+  seat_upgrade: Crown,
+  priority_boarding: Sparkles,
+  lounge_access: DoorOpen,
+  extra_legroom: Armchair,
+};
+
+interface AncillarySelectorProps {
+  cabinClass: string;
+  airport?: string;
+  selectedCodes: string[];
+  onSelectionChange: (items: AncillaryCatalogItem[]) => void;
+  displayCurrency?: CurrencyCode;
+  rates?: Record<string, number>;
+}
+
+export function AncillarySelector({
+  cabinClass,
+  airport,
+  selectedCodes,
+  onSelectionChange,
+  displayCurrency = 'USD',
+  rates,
+}: AncillarySelectorProps) {
+  const [catalog, setCatalog] = useState<AncillaryCatalogItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setIsLoading(true);
+    setError(null);
+    fetchAncillaryCatalog(cabinClass, airport)
+      .then((items) => {
+        if (active) setCatalog(items);
+      })
+      .catch(() => {
+        if (active) setError('Extras are temporarily unavailable. You can continue without them.');
+      })
+      .finally(() => {
+        if (active) setIsLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [airport, cabinClass]);
+
+  const selected = useMemo(
+    () => catalog.filter((item) => selectedCodes.includes(item.code)),
+    [catalog, selectedCodes],
+  );
+  const totalCents = selected.reduce((sum, item) => sum + item.priceCents, 0);
+
+  const formatPrice = (priceCents: number) => {
+    const rate = displayCurrency === 'USD' ? 1 : rates?.[displayCurrency] || 1;
+    return formatCurrency((priceCents / 100) * rate, displayCurrency);
+  };
+
+  const toggle = (item: AncillaryCatalogItem) => {
+    const next = selectedCodes.includes(item.code)
+      ? selected.filter((candidate) => candidate.code !== item.code)
+      : [...selected, item];
+    onSelectionChange(next);
+  };
+
+  return (
+    <section aria-labelledby="ancillary-heading" className="space-y-5">
+      <div>
+        <h2 id="ancillary-heading" className="text-2xl font-bold">Make the trip yours</h2>
+        <p className="text-muted-foreground">
+          Add optional comfort and airport services. You can skip this step.
+        </p>
+      </div>
+
+      {error && <p role="status" className="rounded-lg bg-muted p-4 text-sm">{error}</p>}
+      {isLoading && <p role="status" className="text-sm text-muted-foreground">Loading available extras…</p>}
+
+      {!isLoading && !error && (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {catalog.map((item) => {
+            const Icon = serviceIcons[item.type];
+            const isSelected = selectedCodes.includes(item.code);
+            return (
+              <Card
+                key={item.code}
+                className={cn(
+                  'cursor-pointer transition-colors',
+                  isSelected && 'border-primary bg-primary/5',
+                )}
+                onClick={() => toggle(item)}
+              >
+                <CardHeader>
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="rounded-lg bg-primary/10 p-2 text-primary">
+                      <Icon className="h-5 w-5" aria-hidden="true" />
+                    </div>
+                    <Checkbox
+                      checked={isSelected}
+                      onCheckedChange={() => toggle(item)}
+                      onClick={(event) => event.stopPropagation()}
+                      aria-label={`Select ${item.name}`}
+                    />
+                  </div>
+                  <CardTitle>{item.name}</CardTitle>
+                  <CardDescription>{item.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="flex items-center justify-between">
+                  <span className="font-semibold text-primary">{formatPrice(item.priceCents)}</span>
+                  {item.availableAtGate && <Badge variant="outline">Also at gate</Badge>}
+                  {isSelected && <Check className="h-4 w-4 text-primary" aria-hidden="true" />}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between rounded-xl border bg-card p-4">
+        <span className="text-sm text-muted-foreground">
+          {selected.length} {selected.length === 1 ? 'extra' : 'extras'} selected
+        </span>
+        <span className="font-bold">+{formatPrice(totalCents)}</span>
+      </div>
+    </section>
+  );
+}

--- a/packages/client/components/booking/booking-summary.tsx
+++ b/packages/client/components/booking/booking-summary.tsx
@@ -18,6 +18,7 @@ import {
   Shield,
   Leaf,
   Info,
+  Sparkles,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency, type CurrencyCode } from "@/lib/currency";
@@ -72,6 +73,10 @@ interface BookingSummaryProps {
     count: number;
     totalCents: number;
   };
+  ancillaries?: {
+    count: number;
+    totalCents: number;
+  };
   className?: string;
   displayCurrency?: CurrencyCode;
   rates?: Record<string, number>;
@@ -87,6 +92,7 @@ export function BookingSummary({
   wifi,
   baggage,
   entertainment,
+  ancillaries,
   className,
   displayCurrency = "USD",
   rates,
@@ -112,6 +118,9 @@ export function BookingSummary({
   const entertainmentFare = entertainment
     ? convertPrice(entertainment.totalCents / 100)
     : 0;
+  const ancillaryFare = ancillaries
+    ? convertPrice(ancillaries.totalCents / 100)
+    : 0;
   const subtotal =
     baseFare +
     seatFare +
@@ -120,7 +129,8 @@ export function BookingSummary({
     mealsFare +
     wifiFare +
     baggageFare +
-    entertainmentFare;
+    entertainmentFare +
+    ancillaryFare;
   const taxes = subtotal * 0.08;
   const total = subtotal + taxes;
 
@@ -295,6 +305,17 @@ export function BookingSummary({
                 </span>
                 <span className="font-medium">
                   {formatCurrency(entertainmentFare, displayCurrency)}
+                </span>
+              </div>
+            )}
+            {ancillaries && (
+              <div className="flex justify-between items-center text-sm">
+                <span className="text-muted-foreground flex items-center gap-2">
+                  <Sparkles className="h-4 w-4" />
+                  Trip Extras ({ancillaries.count})
+                </span>
+                <span className="font-medium">
+                  {formatCurrency(ancillaryFare, displayCurrency)}
                 </span>
               </div>
             )}

--- a/packages/client/lib/ancillary-api.ts
+++ b/packages/client/lib/ancillary-api.ts
@@ -1,0 +1,82 @@
+import { API_BASE_URL } from '@/lib/api';
+
+export type AncillaryServiceType =
+  | 'seat_upgrade'
+  | 'priority_boarding'
+  | 'lounge_access'
+  | 'extra_legroom';
+
+export interface AncillaryCatalogItem {
+  code: string;
+  name: string;
+  description: string;
+  type: AncillaryServiceType;
+  priceCents: number;
+  availableCabins: Array<'economy' | 'premium' | 'business' | 'first'>;
+  requiresAirport?: boolean;
+  availableAtGate?: boolean;
+}
+
+export interface AncillaryRevenueReport {
+  totalCents: number;
+  purchaseCount: number;
+  byType: Record<AncillaryServiceType, { totalCents: number; purchaseCount: number }>;
+}
+
+function authorizationHeaders(): HeadersInit {
+  if (typeof window === 'undefined') return {};
+  try {
+    const stored = window.localStorage.getItem('traqora-auth');
+    const parsed = stored ? JSON.parse(stored) : null;
+    const token = parsed?.state?.accessToken;
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  } catch {
+    return {};
+  }
+}
+
+async function readData<T>(response: Response): Promise<T> {
+  const body = await response.json();
+  if (!response.ok) {
+    throw new Error(body?.error?.message || body?.error || 'Ancillary service request failed');
+  }
+  return body.data as T;
+}
+
+export async function fetchAncillaryCatalog(
+  cabinClass: string,
+  airport?: string,
+): Promise<AncillaryCatalogItem[]> {
+  const search = new URLSearchParams({ cabinClass });
+  if (airport) search.set('airport', airport);
+  const response = await fetch(`${API_BASE_URL}/api/v1/ancillary/catalog?${search.toString()}`);
+  return readData<AncillaryCatalogItem[]>(response);
+}
+
+export async function purchaseAncillaryService(input: {
+  bookingId: string;
+  serviceCode: string;
+  quantity?: number;
+  details?: Record<string, string | number | boolean>;
+}): Promise<{ id: string }> {
+  const response = await fetch(`${API_BASE_URL}/api/v1/ancillary/purchases`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authorizationHeaders() },
+    body: JSON.stringify(input),
+  });
+  return readData<{ id: string }>(response);
+}
+
+export async function fetchAncillaryRevenue(
+  from?: Date,
+  to?: Date,
+): Promise<AncillaryRevenueReport> {
+  const search = new URLSearchParams();
+  if (from) search.set('from', from.toISOString());
+  if (to) search.set('to', to.toISOString());
+  const response = await fetch(
+    `${API_BASE_URL}/api/v1/ancillary/revenue?${search.toString()}`,
+    { headers: authorizationHeaders() },
+  );
+  return readData<AncillaryRevenueReport>(response);
+}

--- a/packages/client/tests/ancillary-selector.test.tsx
+++ b/packages/client/tests/ancillary-selector.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { AncillarySelector } from '@/components/booking/ancillary-selector';
+import { fetchAncillaryCatalog } from '@/lib/ancillary-api';
+
+jest.mock('@/lib/ancillary-api', () => ({
+  fetchAncillaryCatalog: jest.fn(),
+}));
+
+const mockedFetchCatalog = fetchAncillaryCatalog as jest.MockedFunction<
+  typeof fetchAncillaryCatalog
+>;
+
+const catalog = [
+  {
+    code: 'PRIORITY_BOARDING',
+    name: 'Priority boarding',
+    description: 'Board before general boarding.',
+    type: 'priority_boarding' as const,
+    priceCents: 2500,
+    availableCabins: ['economy' as const],
+  },
+  {
+    code: 'LOUNGE_STANDARD',
+    name: 'Airport lounge access',
+    description: 'Relax before departure.',
+    type: 'lounge_access' as const,
+    priceCents: 4500,
+    availableCabins: ['economy' as const],
+  },
+];
+
+describe('AncillarySelector', () => {
+  beforeEach(() => {
+    mockedFetchCatalog.mockResolvedValue(catalog);
+  });
+
+  it('loads cabin-aware services and reports selected items', async () => {
+    const onSelectionChange = jest.fn();
+    render(
+      <AncillarySelector
+        cabinClass="economy"
+        airport="JFK"
+        selectedCodes={[]}
+        onSelectionChange={onSelectionChange}
+      />,
+    );
+
+    expect(screen.getByText('Loading available extras…')).toBeInTheDocument();
+    expect(await screen.findByText('Priority boarding')).toBeInTheDocument();
+    expect(mockedFetchCatalog).toHaveBeenCalledWith('economy', 'JFK');
+
+    fireEvent.click(screen.getByLabelText('Select Priority boarding'));
+    expect(onSelectionChange).toHaveBeenCalledWith([catalog[0]]);
+  });
+
+  it('shows the selected count and total', async () => {
+    render(
+      <AncillarySelector
+        cabinClass="economy"
+        selectedCodes={['PRIORITY_BOARDING']}
+        onSelectionChange={jest.fn()}
+      />,
+    );
+
+    await screen.findByText('Priority boarding');
+    expect(screen.getByText('1 extra selected')).toBeInTheDocument();
+    expect(screen.getByText('+$25.00')).toBeInTheDocument();
+  });
+
+  it('fails open so checkout can continue when the catalog is unavailable', async () => {
+    mockedFetchCatalog.mockRejectedValueOnce(new Error('offline'));
+    render(
+      <AncillarySelector
+        cabinClass="economy"
+        selectedCodes={[]}
+        onSelectionChange={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Extras are temporarily unavailable. You can continue without them.'),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Closes #358

## Summary
- add a typed ancillary catalog for seat upgrades, priority boarding, lounge access, and extra-legroom seats
- persist purchases and upgrade bids with a TypeORM entity and migration
- add authenticated purchase/bid/recommendation APIs plus admin-only bid resolution, gate upgrades, and revenue reporting
- enforce server-controlled pricing, wallet ownership, paid-booking gate checks, and upward-only cabin upgrades
- add a selectable trip-extras booking step and an ancillary revenue section to the admin dashboard
- document the API and migration workflow

## Validation
- `npm test --workspace=packages/backend -- --runInBand src/services/ancillaryService.test.ts` — 13/13 passing
- focused coverage — 98.96% statements, 93.75% branches, 94.44% functions, 98.86% lines
- `npm test --workspace=packages/client -- --runInBand tests/ancillary-selector.test.tsx` — 3/3 passing
- changed backend files pass ESLint
- `git diff --check` passes

## Existing repository-wide failures
- backend `npm run typecheck` currently fails in unrelated existing modules (notifications, email, analytics, group bookings, and others); it reports no errors in the new ancillary files
- client full suite: 210/213 tests pass; the three existing failures are in `useFlightStatusAlerts.test.tsx` and `dashboard-receipt.test.tsx`
- client `npm run lint` fails before linting files because the current Next/ESLint configuration throws `Converting circular structure to JSON`
- the full backend Jest run does not terminate within 10 minutes even with `--forceExit`; the focused ancillary suite completes cleanly