### PR TITLE
feat: add booking receipt integration tests and enhance contract test…

### DIFF
--- a/contracts/TEST_IMPLEMENTATION_STATUS.md
+++ b/contracts/TEST_IMPLEMENTATION_STATUS.md
@@ -69,36 +69,38 @@
 
 ### 📊 Test Coverage Summary
 
-#### Current Test Files (23 files total)
+#### Current Test Files (26 files total)
 1. `access_test.rs` - Authorization tests
 2. `admin_multisig_test.rs` - Admin multisig (149 tests, PR #81)
 3. `airline_test.rs` - Airline operations
 4. `booking_errors_test.rs` - Error handling
-5. `booking_test.rs` - Booking operations
-6. `common.rs` - Shared utilities
-7. `dispute_resolution_test.rs` - Basic dispute tests
-8. **`dispute_resolution_advanced_test.rs`** - ✨ NEW advanced tests
-9. `dispute_test.rs` - Dispute contract tests
-10. `event_assertions_test.rs` - Event validation
-11. `flight_booking_test.rs` - Flight booking
-12. `flight_registry_test.rs` - Flight registry
-13. `fuzz_property_test.rs` - Property tests (existing)
-14. `governance_test.rs` - Governance tests
-15. `integration_test.rs` - Basic integration tests
-16. `loyalty_test.rs` - Loyalty points
-17. `oracle_test.rs` - Oracle integration
-18. `proxy_access_test.rs` - Proxy access
-19. `proxy_test.rs` - Proxy behavior
-20. `refund_automation_integration_test.rs` - Refund automation
-21. `refund_test.rs` - Refund operations
-22. `storage_version_test.rs` - Versioning
-23. `token_test.rs` - Token operations
-24. **`comprehensive_integration_test.rs`** - ✨ NEW comprehensive tests
-25. **`advanced_property_tests.rs`** - ✨ NEW property tests
+5. **`booking_receipt_test.rs`** - ✨ Booking receipt soulbound token tests
+6. `booking_test.rs` - Booking operations
+7. `common.rs` - Shared utilities
+8. `dispute_resolution_test.rs` - Basic dispute tests
+9. **`dispute_resolution_advanced_test.rs`** - ✨ Advanced dispute tests
+10. `dispute_test.rs` - Dispute contract tests
+11. `event_assertions_test.rs` - Event validation
+12. `flight_booking_test.rs` - Flight booking
+13. `flight_registry_test.rs` - Flight registry
+14. `fuzz_property_test.rs` - Property tests (existing)
+15. `governance_test.rs` - Governance tests
+16. `integration_test.rs` - Basic integration tests
+17. `loyalty_test.rs` - Loyalty points
+18. `oracle_test.rs` - Oracle integration
+19. `proxy_access_test.rs` - Proxy access
+20. `proxy_test.rs` - Proxy behavior
+21. `refund_automation_integration_test.rs` - Refund automation
+22. `refund_test.rs` - Refund operations
+23. `storage_version_test.rs` - Versioning
+24. `token_test.rs` - Token operations
+25. **`comprehensive_integration_test.rs`** - ✨ Comprehensive integration tests
+26. **`advanced_property_tests.rs`** - ✨ Property-based tests
 
 #### Coverage Targets by Module
 - Token (TRQ): 95%+ ⭐ Critical
 - Booking: 90%+ ⭐ Critical
+- Booking Receipt: 90%+ ⭐ Critical
 - Refund: 90%+ ⭐ Critical
 - Refund Automation: 90%+ ⭐ Critical
 - Admin/Multisig: 93%+ ⭐ Critical

--- a/contracts/packages/integration-tests/Cargo.toml
+++ b/contracts/packages/integration-tests/Cargo.toml
@@ -22,6 +22,7 @@ refund = { workspace = true }
 refund-automation = { workspace = true }
 token = { workspace = true }
 upgrade = { workspace = true }
+booking-receipt = { workspace = true }
 admin = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/packages/integration-tests/src/lib.rs
+++ b/contracts/packages/integration-tests/src/lib.rs
@@ -1,6 +1,7 @@
 use soroban_sdk::{testutils::Address as _, Address, Env, String, Symbol};
 use airline::{AirlineContract, AirlineContractClient};
 use booking::{BookingContract, BookingContractClient};
+use booking_receipt::{BookingReceiptContract, BookingReceiptContractClient};
 use governance::{GovernanceContract, GovernanceContractClient};
 use loyalty::{LoyaltyContract, LoyaltyContractClient};
 use refund::{RefundContract, RefundContractClient};
@@ -18,6 +19,7 @@ pub struct Contracts<'a> {
     pub governance: GovernanceContractClient<'a>,
     pub refund: RefundContractClient<'a>,
     pub refund_automation: RefundAutomationContractClient<'a>,
+    pub booking_receipt: BookingReceiptContractClient<'a>,
 }
 
 pub struct Actors {
@@ -48,6 +50,7 @@ pub fn register_contracts<'a>(env: &'a Env) -> Contracts<'a> {
     let governance_id = env.register(GovernanceContract, ());
     let refund_id = env.register(RefundContract, ());
     let refund_automation_id = env.register(RefundAutomationContract, ());
+    let booking_receipt_id = env.register(BookingReceiptContract, ());
 
     Contracts {
         token: TRQTokenContractClient::new(env, &token_id),
@@ -57,6 +60,7 @@ pub fn register_contracts<'a>(env: &'a Env) -> Contracts<'a> {
         governance: GovernanceContractClient::new(env, &governance_id),
         refund: RefundContractClient::new(env, &refund_id),
         refund_automation: RefundAutomationContractClient::new(env, &refund_automation_id),
+        booking_receipt: BookingReceiptContractClient::new(env, &booking_receipt_id),
     }
 }
 

--- a/contracts/packages/integration-tests/tests/booking_receipt_test.rs
+++ b/contracts/packages/integration-tests/tests/booking_receipt_test.rs
@@ -1,0 +1,134 @@
+use integration_tests::{generate_actors, initialize_token, new_env, register_contracts};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger, Address, Env, String, Symbol};
+
+fn init_receipt_contract(env: &Env, contracts: &integration_tests::Contracts, admin: &Address) {
+    contracts.booking_receipt.initialize(
+        admin,
+        &String::from_str(env, "Traqora Receipt"),
+        &Symbol::new(env, "TREC"),
+    );
+}
+
+#[test]
+fn test_mint_and_verify_receipt() {
+    let env = new_env();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1672531200);
+
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    initialize_token(&env, &contracts.token, &actors.admin);
+    init_receipt_contract(&env, &contracts, &actors.admin);
+
+    let receipt_id = contracts.booking_receipt.mint_receipt(
+        &actors.passenger,
+        &1001,
+        &Symbol::new(&env, "TRQ101"),
+        &Symbol::new(&env, "JFK"),
+        &Symbol::new(&env, "LHR"),
+        &String::from_str(&env, "12A"),
+        &500_0000000,
+    );
+
+    assert_eq!(receipt_id, 1);
+    assert_eq!(contracts.booking_receipt.sbt_balance(&actors.passenger), 1);
+    assert!(contracts.booking_receipt.verify_receipt(&actors.passenger, &1));
+
+    let other = Address::generate(&env);
+    assert!(!contracts.booking_receipt.verify_receipt(&other, &1));
+
+    let metadata = contracts.booking_receipt.get_receipt_metadata(&1);
+    assert_eq!(metadata.booking_id, 1001);
+    assert_eq!(metadata.price, 500_0000000);
+}
+
+#[test]
+fn test_multiple_receipts_per_passenger() {
+    let env = new_env();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1672531200);
+
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    initialize_token(&env, &contracts.token, &actors.admin);
+    init_receipt_contract(&env, &contracts, &actors.admin);
+
+    let id1 = contracts.booking_receipt.mint_receipt(
+        &actors.passenger, &1001,
+        &Symbol::new(&env, "FL101"), &Symbol::new(&env, "JFK"), &Symbol::new(&env, "LAX"),
+        &String::from_str(&env, "10A"), &200_0000000,
+    );
+    let id2 = contracts.booking_receipt.mint_receipt(
+        &actors.passenger, &1002,
+        &Symbol::new(&env, "FL202"), &Symbol::new(&env, "LAX"), &Symbol::new(&env, "SFO"),
+        &String::from_str(&env, "5B"), &150_0000000,
+    );
+
+    assert_eq!(id1, 1);
+    assert_eq!(id2, 2);
+    assert_eq!(contracts.booking_receipt.sbt_balance(&actors.passenger), 2);
+
+    let receipts = contracts.booking_receipt.get_passenger_receipts(&actors.passenger);
+    assert_eq!(receipts.len(), 2);
+    assert_eq!(receipts.get(0).unwrap(), 1);
+    assert_eq!(receipts.get(1).unwrap(), 2);
+}
+
+#[test]
+fn test_receipt_metadata_integrity() {
+    let env = new_env();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1700000000);
+
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    initialize_token(&env, &contracts.token, &actors.admin);
+    init_receipt_contract(&env, &contracts, &actors.admin);
+
+    let receipt_id = contracts.booking_receipt.mint_receipt(
+        &actors.passenger, &42,
+        &Symbol::new(&env, "AA789"), &Symbol::new(&env, "ORD"), &Symbol::new(&env, "MIA"),
+        &String::from_str(&env, "22F"), &350_0000000,
+    );
+
+    let metadata = contracts.booking_receipt.get_receipt_metadata(&receipt_id);
+    assert_eq!(metadata.booking_id, 42);
+    assert_eq!(metadata.flight_number, Symbol::new(&env, "AA789"));
+    assert_eq!(metadata.from_airport, Symbol::new(&env, "ORD"));
+    assert_eq!(metadata.to_airport, Symbol::new(&env, "MIA"));
+    assert_eq!(metadata.seat, String::from_str(&env, "22F"));
+    assert_eq!(metadata.timestamp, 1700000000);
+    assert_eq!(metadata.price, 350_0000000);
+}
+
+#[test]
+#[should_panic(expected = "Not initialized")]
+fn test_uninitialized_receipt_fails() {
+    let env = new_env();
+    env.mock_all_auths();
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    initialize_token(&env, &contracts.token, &actors.admin);
+
+    contracts.booking_receipt.mint_receipt(
+        &actors.passenger, &1,
+        &Symbol::new(&env, "FL001"), &Symbol::new(&env, "JFK"), &Symbol::new(&env, "LHR"),
+        &String::from_str(&env, "1A"), &100_0000000,
+    );
+}
+
+#[test]
+fn test_receipt_sbt_interface() {
+    let env = new_env();
+    env.mock_all_auths();
+
+    let actors = generate_actors(&env);
+    let contracts = register_contracts(&env);
+    initialize_token(&env, &contracts.token, &actors.admin);
+    init_receipt_contract(&env, &contracts, &actors.admin);
+
+    assert_eq!(contracts.booking_receipt.sbt_name(), String::from_str(&env, "Traqora Receipt"));
+    assert_eq!(contracts.booking_receipt.sbt_symbol(), Symbol::new(&env, "TREC"));
+    assert_eq!(contracts.booking_receipt.sbt_decimals(), 0);
+    assert_eq!(contracts.booking_receipt.sbt_allowance(&actors.passenger, &actors.airline), 0);
+}


### PR DESCRIPTION
closes #325 
closes #324 
closes #327 
closes #323 

- Add booking_receipt to integration test dependencies and shared test helpers
- Create booking_receipt_test.rs with 5 integration tests covering mint, verify, multiple receipts, metadata integrity, uninitialized guard, and SBT interface
- Update TEST_IMPLEMENTATION_STATUS.md with new test file